### PR TITLE
feat: add Phase 7 character management backend

### DIFF
--- a/config/llm_config.yaml
+++ b/config/llm_config.yaml
@@ -44,9 +44,16 @@ llm_configs:
     api_key: ${COMPRESS_API_KEY}       # API 密钥（从环境变量读取）
     temperature: 0.3                   # 采样温度：压缩场景使用较低值以确保稳定性
 
+  title_gen:
+    provider: openai_compatible        # 提供商名称，须与工厂注册名一致
+    model: deepseek-ai/DeepSeek-V3.2       # 使用更轻量/更便宜的模型以降低压缩成本
+    base_url: https://api.siliconflow.cn/v1    # API 基础 URL（从环境变量读取）
+    api_key: ${COMPRESS_API_KEY}       # API 密钥（从环境变量读取）
+    temperature: 0.3                   # 采样温度：压缩场景使用较低值以确保稳定性
+
 # 角色映射：将每个调用位点映射到 llm_configs 中的某个池条目
 llm_roles:
   chat: chat_main              # 聊天调用位点 -> chat_main
   l3_compress: compress_light  # L3 滚动压缩 -> compress_light
   l4_compact: compress_light   # L4 整合压缩 -> compress_light
-  title_gen: compress_light    # 标题生成 -> compress_light（轻量模型即可）
+  title_gen: title_gen         # 标题生成 -> title_gen（轻量模型即可）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "loguru>=0.7.3",
     "mem0ai>=2.0.0",
     "openai>=2.32.0",
+    "python-multipart>=0.0.20",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0.3",
     "uvicorn>=0.44.0",

--- a/src/agent/persona.py
+++ b/src/agent/persona.py
@@ -35,6 +35,7 @@ closing ``---`` 之后的正文原样作为 LLM system prompt。``character_id``
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date, datetime
 from pathlib import Path
 from typing import Any
 
@@ -78,6 +79,33 @@ class Persona:
     avatar: str | None
     greeting: str | None
     system_prompt: str
+    description: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    managed_by: str | None = None
+
+
+def _coerce_optional_text(value: Any) -> str | None:
+    """Normalize optional metadata to stripped strings."""
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        text = value.isoformat()
+    elif isinstance(value, date):
+        text = value.isoformat()
+    else:
+        text = str(value).strip()
+
+    return text or None
+
+
+def _coerce_optional_timestamp(value: Any) -> str | None:
+    """Normalize YAML timestamp values to stable ISO-like strings."""
+    text = _coerce_optional_text(value)
+    if text is None:
+        return None
+    return text.replace("+00:00", "Z")
 
 
 def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
@@ -125,6 +153,39 @@ def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
     return meta, body
 
 
+def parse_persona_text(character_id: str, text: str) -> Persona:
+    """Parse persona markdown content into a Persona instance."""
+    meta, body = _split_frontmatter(text)
+
+    name = meta.get("name", character_id)
+    avatar = meta.get("avatar")
+    greeting = meta.get("greeting")
+    description = meta.get("description")
+    created_at = meta.get("created_at")
+    updated_at = meta.get("updated_at")
+    managed_by = meta.get("managed_by")
+
+    return Persona(
+        character_id=character_id,
+        name=str(name),
+        avatar=_coerce_optional_text(avatar),
+        greeting=_coerce_optional_text(greeting),
+        system_prompt=body,
+        description=_coerce_optional_text(description),
+        created_at=_coerce_optional_timestamp(created_at),
+        updated_at=_coerce_optional_timestamp(updated_at),
+        managed_by=_coerce_optional_text(managed_by),
+    )
+
+
+def load_persona_from_path(path: Path) -> Persona:
+    """Load persona markdown from an explicit file path."""
+    if not path.is_file():
+        raise FileNotFoundError(f"Persona file not found: {path}")
+
+    return parse_persona_text(path.stem, path.read_text(encoding="utf-8-sig"))
+
+
 def load_persona(character_id: str) -> Persona:
     """Load ``prompts/persona/{character_id}.md`` and return a :class:`Persona`.
 
@@ -159,19 +220,7 @@ def load_persona(character_id: str) -> Persona:
         ValueError：当 frontmatter 格式不合法时（见 :func:`_split_frontmatter`）。
     """
     text = _load_persona_text(character_id)
-    meta, body = _split_frontmatter(text)
-
-    name = meta.get("name", character_id)
-    avatar = meta.get("avatar")
-    greeting = meta.get("greeting")
-
-    return Persona(
-        character_id=character_id,
-        name=str(name),
-        avatar=str(avatar) if avatar is not None else None,
-        greeting=str(greeting) if greeting is not None else None,
-        system_prompt=body,
-    )
+    return parse_persona_text(character_id, text)
 
 
 def list_personas() -> list[str]:
@@ -193,4 +242,10 @@ def list_personas() -> list[str]:
     return sorted(p.stem for p in _PERSONA_DIR.glob("*.md") if p.is_file())
 
 
-__all__ = ["Persona", "load_persona", "list_personas"]
+__all__ = [
+    "Persona",
+    "load_persona",
+    "load_persona_from_path",
+    "list_personas",
+    "parse_persona_text",
+]

--- a/src/app.py
+++ b/src/app.py
@@ -37,9 +37,11 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
 from src.service_context import ServiceContext
+from src.storage.character_storage import CharacterStorage, get_default_character_avatar_dir
 from src.storage.factory import create_chat_storage
 
 
@@ -97,6 +99,15 @@ def create_app(config: dict) -> FastAPI:
     # Store config in app state for lifespan access
     # 将配置存储在 app state 中供 lifespan 访问
     app.state.config = config
+    app.state.character_storage = CharacterStorage()
+
+    avatar_dir = get_default_character_avatar_dir()
+    avatar_dir.mkdir(parents=True, exist_ok=True)
+    app.mount(
+        "/api/assets/avatars",
+        StaticFiles(directory=str(avatar_dir), check_dir=False),
+        name="character-avatar-assets",
+    )
 
     # Configure CORS
     # 配置 CORS

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -1,0 +1,17 @@
+"""Pydantic request and response schemas."""
+
+from .character import (
+    AvatarUploadResponse,
+    CharacterCreateRequest,
+    CharacterDetail,
+    CharacterSummary,
+    CharacterUpdateRequest,
+)
+
+__all__ = [
+    "AvatarUploadResponse",
+    "CharacterCreateRequest",
+    "CharacterDetail",
+    "CharacterSummary",
+    "CharacterUpdateRequest",
+]

--- a/src/models/character.py
+++ b/src/models/character.py
@@ -1,0 +1,52 @@
+"""Character API schemas used by Phase 7."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class CharacterSummary(BaseModel):
+    """Character summary returned by list endpoints."""
+
+    character_id: str
+    name: str
+    avatar: str | None = None
+    avatar_url: str | None = None
+    greeting: str | None = None
+    description: str | None = None
+    created_at: str | None = None
+    updated_at: str | None = None
+    is_system: bool = True
+
+
+class CharacterDetail(CharacterSummary):
+    """Character detail with full system prompt."""
+
+    system_prompt: str
+
+
+class CharacterCreateRequest(BaseModel):
+    """Payload for creating a character."""
+
+    character_id: str | None = Field(default=None, max_length=64)
+    name: str = Field(..., min_length=1, max_length=50)
+    greeting: str | None = Field(default=None, max_length=500)
+    description: str | None = Field(default=None, max_length=200)
+    system_prompt: str = Field(..., min_length=1, max_length=4000)
+
+
+class CharacterUpdateRequest(BaseModel):
+    """Payload for updating a character."""
+
+    name: str | None = Field(default=None, min_length=1, max_length=50)
+    greeting: str | None = Field(default=None, max_length=500)
+    description: str | None = Field(default=None, max_length=200)
+    system_prompt: str | None = Field(default=None, min_length=1, max_length=4000)
+
+
+class AvatarUploadResponse(BaseModel):
+    """Response payload for avatar upload."""
+
+    character_id: str
+    avatar: str
+    avatar_url: str

--- a/src/routes/characters.py
+++ b/src/routes/characters.py
@@ -1,92 +1,198 @@
-"""
-Character management REST API routes.
-角色管理 REST API 路由。
+"""Character management REST API routes."""
 
-Provides endpoints for listing and retrieving character personas.
-提供角色列表和详情查询端点。
-"""
+from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException
-from pydantic import BaseModel
+from typing import Annotated
 
-from ..agent.persona import list_personas, load_persona
+from fastapi import APIRouter, Depends, File, HTTPException, Request, Response, UploadFile, status
+
+from ..models.character import (
+    AvatarUploadResponse,
+    CharacterCreateRequest,
+    CharacterDetail,
+    CharacterSummary,
+    CharacterUpdateRequest,
+)
+from ..storage.character_storage import (
+    AvatarValidationError,
+    CharacterNameConflictError,
+    CharacterNotFoundError,
+    CharacterStorage,
+    CharacterStorageError,
+    CharacterSystemDeleteError,
+)
 
 router = APIRouter(prefix="/api/characters", tags=["characters"])
 
 
-class CharacterListItem(BaseModel):
-    """Character list item (without system_prompt). / 角色列表项（不含系统提示词）"""
+def get_character_storage(request: Request) -> CharacterStorage:
+    """Return app-scoped character storage, creating a default one if needed."""
 
-    character_id: str
-    name: str
-    avatar: str | None
-    greeting: str | None
-
-
-class CharacterDetail(BaseModel):
-    """Character detail (with system_prompt). / 角色详情（含系统提示词）"""
-
-    character_id: str
-    name: str
-    avatar: str | None
-    greeting: str | None
-    system_prompt: str
+    storage = getattr(request.app.state, "character_storage", None)
+    if storage is None:
+        storage = CharacterStorage()
+        request.app.state.character_storage = storage
+    return storage
 
 
-@router.get("", response_model=list[CharacterListItem])
-async def list_characters() -> list[CharacterListItem]:
-    """
-    List all available characters (without system_prompt).
-    列出所有可用角色（不含系统提示词）。
+CharacterStorageDep = Annotated[CharacterStorage, Depends(get_character_storage)]
+AvatarFile = Annotated[UploadFile, File(...)]
 
-    Returns:
-        List of character metadata (character_id, name, avatar, greeting).
-        角色元数据列表（角色ID、名称、头像、问候语）。
-    """
-    character_ids = list_personas()
-    characters = []
 
-    for cid in character_ids:
-        persona = load_persona(cid)
-        characters.append(
-            CharacterListItem(
-                character_id=cid,
-                name=persona.name,
-                avatar=persona.avatar,
-                greeting=persona.greeting,
-            )
+def _serialize_character(
+    record,
+    request: Request,
+    storage: CharacterStorage,
+) -> CharacterDetail:
+    avatar_url = storage.build_avatar_url(record.avatar, str(request.base_url))
+    return CharacterDetail(
+        character_id=record.character_id,
+        name=record.name,
+        avatar=record.avatar,
+        avatar_url=avatar_url,
+        greeting=record.greeting,
+        description=record.description,
+        created_at=record.created_at,
+        updated_at=record.updated_at,
+        is_system=record.is_system,
+        system_prompt=record.system_prompt,
+    )
+
+
+def _handle_character_error(error: Exception) -> HTTPException:
+    if isinstance(error, CharacterNotFoundError):
+        return HTTPException(status_code=404, detail=str(error))
+    if isinstance(error, CharacterNameConflictError):
+        return HTTPException(status_code=400, detail=str(error))
+    if isinstance(error, CharacterSystemDeleteError):
+        return HTTPException(status_code=400, detail=str(error))
+    if isinstance(error, AvatarValidationError):
+        return HTTPException(status_code=400, detail=str(error))
+    if isinstance(error, CharacterStorageError):
+        return HTTPException(status_code=400, detail=str(error))
+    return HTTPException(status_code=500, detail="Character storage operation failed")
+
+
+@router.get("", response_model=list[CharacterSummary])
+async def list_characters(
+    request: Request,
+    storage: CharacterStorageDep,
+) -> list[CharacterSummary]:
+    """List all characters without changing the existing read API shape."""
+
+    records = storage.list_characters()
+    return [
+        CharacterSummary(
+            character_id=record.character_id,
+            name=record.name,
+            avatar=record.avatar,
+            avatar_url=storage.build_avatar_url(record.avatar, str(request.base_url)),
+            greeting=record.greeting,
+            description=record.description,
+            created_at=record.created_at,
+            updated_at=record.updated_at,
+            is_system=record.is_system,
         )
-
-    return characters
+        for record in records
+    ]
 
 
 @router.get("/{character_id}", response_model=CharacterDetail)
-async def get_character(character_id: str) -> CharacterDetail:
-    """
-    Get character detail (with system_prompt).
-    获取角色详情（含系统提示词）。
+async def get_character(
+    character_id: str,
+    request: Request,
+    storage: CharacterStorageDep,
+) -> CharacterDetail:
+    """Get one character with its full system prompt."""
 
-    Args:
-        character_id: Character identifier.
-                      角色标识符。
-
-    Returns:
-        Full character metadata including system_prompt.
-        完整角色元数据（含系统提示词）。
-
-    Raises:
-        HTTPException: 404 if character not found.
-                       角色不存在时返回 404。
-    """
     try:
-        persona = load_persona(character_id)
-    except FileNotFoundError as e:
-        raise HTTPException(status_code=404, detail=f"Character '{character_id}' not found") from e
+        record = storage.get_character(character_id)
+    except Exception as error:
+        raise _handle_character_error(error) from error
 
-    return CharacterDetail(
-        character_id=character_id,
-        name=persona.name,
-        avatar=persona.avatar,
-        greeting=persona.greeting,
-        system_prompt=persona.system_prompt,
+    return _serialize_character(record, request, storage)
+
+
+@router.post("", response_model=CharacterDetail, status_code=status.HTTP_201_CREATED)
+async def create_character(
+    payload: CharacterCreateRequest,
+    request: Request,
+    storage: CharacterStorageDep,
+) -> CharacterDetail:
+    """Create a new character."""
+
+    try:
+        record = storage.create_character(
+            character_id=payload.character_id,
+            name=payload.name,
+            greeting=payload.greeting,
+            description=payload.description,
+            system_prompt=payload.system_prompt,
+        )
+    except Exception as error:
+        raise _handle_character_error(error) from error
+
+    return _serialize_character(record, request, storage)
+
+
+@router.put("/{character_id}", response_model=CharacterDetail)
+async def update_character(
+    character_id: str,
+    payload: CharacterUpdateRequest,
+    request: Request,
+    storage: CharacterStorageDep,
+) -> CharacterDetail:
+    """Update an existing character."""
+
+    try:
+        record = storage.update_character(
+            character_id,
+            name=payload.name,
+            greeting=payload.greeting,
+            description=payload.description,
+            system_prompt=payload.system_prompt,
+        )
+    except Exception as error:
+        raise _handle_character_error(error) from error
+
+    return _serialize_character(record, request, storage)
+
+
+@router.delete("/{character_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_character(
+    character_id: str,
+    storage: CharacterStorageDep,
+) -> Response:
+    """Delete a managed character."""
+
+    try:
+        storage.delete_character(character_id)
+    except Exception as error:
+        raise _handle_character_error(error) from error
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/{character_id}/avatar", response_model=AvatarUploadResponse)
+async def upload_character_avatar(
+    character_id: str,
+    request: Request,
+    avatar: AvatarFile,
+    storage: CharacterStorageDep,
+) -> AvatarUploadResponse:
+    """Upload or replace a character avatar."""
+
+    try:
+        record = await storage.save_avatar(character_id, avatar)
+    except Exception as error:
+        raise _handle_character_error(error) from error
+
+    avatar_url = storage.build_avatar_url(record.avatar, str(request.base_url))
+    if avatar_url is None or record.avatar is None:
+        raise HTTPException(status_code=500, detail="Character avatar URL could not be generated")
+
+    return AvatarUploadResponse(
+        character_id=record.character_id,
+        avatar=record.avatar,
+        avatar_url=avatar_url,
     )

--- a/src/routes/chats.py
+++ b/src/routes/chats.py
@@ -13,7 +13,10 @@ Provides endpoints for chat session management:
 Reference: docs/Phase5_执行规格.md §US-SRV-005
 """
 
-from fastapi import APIRouter, HTTPException, Query, Request
+import re
+from typing import Any
+
+from fastapi import APIRouter, BackgroundTasks, HTTPException, Query, Request
 from loguru import logger
 from pydantic import BaseModel
 
@@ -28,6 +31,7 @@ class CreateChatRequest(BaseModel):
 
     character_id: str
     first_message: str
+    defer_title: bool = False
 
 
 class CreateChatResponse(BaseModel):
@@ -126,6 +130,20 @@ async def _generate_title_with_llm(first_message: str, llm_config: dict) -> str 
         return None
 
 
+def _temporary_title(first_message: str) -> str:
+    """Build a fast temporary title from the first sentence's first 8 chars.
+
+    使用首句话前 8 个字符构建临时标题。
+    """
+    cleaned = " ".join(first_message.split()).strip()
+    if not cleaned:
+        return "新对话"
+
+    sentence = re.split(r"[。！？!?；;\n\r]+", cleaned, maxsplit=1)[0].strip()
+    candidate = sentence or cleaned
+    return candidate[:8] if len(candidate) > 8 else candidate
+
+
 def _fallback_title(first_message: str) -> str:
     """Generate fallback title by truncating first message.
     通过截取首条消息生成降级标题。
@@ -139,6 +157,28 @@ def _fallback_title(first_message: str) -> str:
         截取的标题（最多 20 字符）。
     """
     return first_message[:20] if len(first_message) > 20 else first_message
+
+
+async def _backfill_chat_title(
+    chat_id: str,
+    first_message: str,
+    llm_config: dict[str, Any],
+    storage: Any,
+) -> None:
+    """Generate a better title asynchronously and patch chat metadata.
+
+    异步生成更好的标题，并回填聊天元数据。
+    """
+    title = await _generate_title_with_llm(first_message, llm_config)
+    if not title:
+        logger.info(f"Deferred title generation skipped | chat_id={chat_id}")
+        return
+
+    try:
+        await storage.update_chat(chat_id, title=title)
+        logger.info(f"Deferred title updated | chat_id={chat_id} | title={title}")
+    except Exception as exc:
+        logger.warning(f"Deferred title update failed | chat_id={chat_id} | error={exc}")
 
 
 @router.get("", response_model=list[ChatListItem])
@@ -165,7 +205,11 @@ async def list_chats(
 
 
 @router.post("", response_model=CreateChatResponse, status_code=201)
-async def create_chat(request: Request, body: CreateChatRequest) -> CreateChatResponse:
+async def create_chat(
+    request: Request,
+    body: CreateChatRequest,
+    background_tasks: BackgroundTasks,
+) -> CreateChatResponse:
     """Create a new chat session with LLM-generated title.
     创建新聊天会话，使用 LLM 生成标题。
 
@@ -181,20 +225,37 @@ async def create_chat(request: Request, body: CreateChatRequest) -> CreateChatRe
     config = request.app.state.config
     user_id = "default"  # Phase 5: hardcoded user_id
 
-    # Generate title with LLM (with fallback)
-    # 使用 LLM 生成标题（带降级）
     llm_config = config.get("llm", {})
-    title = await _generate_title_with_llm(body.first_message, llm_config)
 
-    if not title:
-        title = _fallback_title(body.first_message)
-        logger.info(f"Using fallback title: {title}")
+    title: str
+
+    if body.defer_title:
+        title = _temporary_title(body.first_message)
+        logger.info(f"Using deferred temporary title: {title}")
     else:
-        logger.info(f"Generated title: {title}")
+        # Generate title with LLM (with fallback)
+        # 使用 LLM 生成标题（带降级）
+        generated_title = await _generate_title_with_llm(body.first_message, llm_config)
+
+        if not generated_title:
+            title = _fallback_title(body.first_message)
+            logger.info(f"Using fallback title: {title}")
+        else:
+            title = generated_title
+            logger.info(f"Generated title: {title}")
 
     # Create chat in storage
     # 在存储中创建聊天
     chat_meta = await storage.create_chat(user_id, body.character_id, title)
+
+    if body.defer_title:
+        background_tasks.add_task(
+            _backfill_chat_title,
+            chat_meta["id"],
+            body.first_message,
+            llm_config,
+            storage,
+        )
 
     return CreateChatResponse(
         id=chat_meta["id"],

--- a/src/storage/character_storage.py
+++ b/src/storage/character_storage.py
@@ -1,0 +1,322 @@
+"""Character storage backed by persona markdown files and managed avatars."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import yaml
+from fastapi import UploadFile
+
+from src.agent.persona import Persona, load_persona_from_path
+
+MANAGED_BY_ATRI = "atri"
+MAX_AVATAR_SIZE_BYTES = 2 * 1024 * 1024
+ALLOWED_AVATAR_CONTENT_TYPES = {
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+}
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_PERSONA_DIR = _PROJECT_ROOT / "prompts" / "persona"
+_DEFAULT_AVATAR_DIR = _PROJECT_ROOT / "data" / "avatars"
+
+
+class CharacterStorageError(Exception):
+    """Base exception for character storage operations."""
+
+
+class CharacterNotFoundError(CharacterStorageError):
+    """Raised when a character file does not exist."""
+
+
+class CharacterNameConflictError(CharacterStorageError):
+    """Raised when a character name duplicates another character."""
+
+
+class CharacterSystemDeleteError(CharacterStorageError):
+    """Raised when attempting to delete a protected system character."""
+
+
+class AvatarValidationError(CharacterStorageError):
+    """Raised when avatar upload validation fails."""
+
+
+@dataclass(frozen=True)
+class CharacterRecord:
+    """Character record loaded from persona markdown."""
+
+    character_id: str
+    name: str
+    avatar: str | None
+    greeting: str | None
+    description: str | None
+    system_prompt: str
+    created_at: str | None
+    updated_at: str | None
+    managed_by: str | None
+
+    @property
+    def is_system(self) -> bool:
+        return self.managed_by != MANAGED_BY_ATRI
+
+
+def get_default_character_persona_dir() -> Path:
+    """Return the default persona directory used by the backend."""
+
+    return _DEFAULT_PERSONA_DIR
+
+
+def get_default_character_avatar_dir() -> Path:
+    """Return the default managed avatar directory used by the backend."""
+
+    return _DEFAULT_AVATAR_DIR
+
+
+def _now_iso_z() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _slugify_character_id(value: str) -> str:
+    normalized = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
+    normalized = normalized.strip("-")
+    return normalized
+
+
+class CharacterStorage:
+    """Read and write characters using persona markdown files."""
+
+    def __init__(self, persona_dir: Path | None = None, avatar_dir: Path | None = None) -> None:
+        self.persona_dir = persona_dir or get_default_character_persona_dir()
+        self.avatar_dir = avatar_dir or get_default_character_avatar_dir()
+
+        self.persona_dir.mkdir(parents=True, exist_ok=True)
+        self.avatar_dir.mkdir(parents=True, exist_ok=True)
+
+    def list_characters(self) -> list[CharacterRecord]:
+        """List all character records sorted by name."""
+
+        records = [self.get_character(path.stem) for path in sorted(self.persona_dir.glob("*.md"))]
+        return sorted(records, key=lambda record: (record.name.casefold(), record.character_id))
+
+    def get_character(self, character_id: str) -> CharacterRecord:
+        """Load a single character by its identifier."""
+
+        path = self._character_path(character_id)
+        if not path.is_file():
+            raise CharacterNotFoundError(f"Character '{character_id}' not found")
+
+        persona = load_persona_from_path(path)
+        return self._record_from_persona(persona)
+
+    def create_character(
+        self,
+        *,
+        character_id: str | None,
+        name: str,
+        greeting: str | None,
+        description: str | None,
+        system_prompt: str,
+    ) -> CharacterRecord:
+        """Create a new managed character."""
+
+        clean_name = name.strip()
+        clean_system_prompt = system_prompt.strip()
+        clean_greeting = greeting.strip() if greeting else None
+        clean_description = description.strip() if description else None
+
+        if not clean_name:
+            raise CharacterStorageError("Character name cannot be empty")
+        if not clean_system_prompt:
+            raise CharacterStorageError("System prompt cannot be empty")
+
+        self._ensure_unique_name(clean_name)
+        resolved_id = self._resolve_character_id(character_id, clean_name)
+        now = _now_iso_z()
+
+        record = CharacterRecord(
+            character_id=resolved_id,
+            name=clean_name,
+            avatar=None,
+            greeting=clean_greeting,
+            description=clean_description,
+            system_prompt=clean_system_prompt,
+            created_at=now,
+            updated_at=now,
+            managed_by=MANAGED_BY_ATRI,
+        )
+        self._write_character(record)
+        return record
+
+    def update_character(
+        self,
+        character_id: str,
+        *,
+        name: str | None = None,
+        greeting: str | None = None,
+        description: str | None = None,
+        system_prompt: str | None = None,
+    ) -> CharacterRecord:
+        """Update an existing character."""
+
+        current = self.get_character(character_id)
+
+        next_name = name.strip() if name is not None else current.name
+        next_greeting = greeting.strip() if greeting is not None else current.greeting
+        next_description = description.strip() if description is not None else current.description
+        next_system_prompt = (
+            system_prompt.strip() if system_prompt is not None else current.system_prompt
+        )
+
+        if not next_name:
+            raise CharacterStorageError("Character name cannot be empty")
+        if not next_system_prompt:
+            raise CharacterStorageError("System prompt cannot be empty")
+
+        self._ensure_unique_name(next_name, ignore_character_id=character_id)
+
+        record = CharacterRecord(
+            character_id=current.character_id,
+            name=next_name,
+            avatar=current.avatar,
+            greeting=next_greeting,
+            description=next_description,
+            system_prompt=next_system_prompt,
+            created_at=current.created_at,
+            updated_at=_now_iso_z(),
+            managed_by=current.managed_by,
+        )
+        self._write_character(record)
+        return record
+
+    def delete_character(self, character_id: str) -> None:
+        """Delete a managed character and its uploaded avatar, if any."""
+
+        record = self.get_character(character_id)
+        if record.is_system:
+            raise CharacterSystemDeleteError(
+                f"Character '{character_id}' is a protected system character and cannot be deleted"
+            )
+
+        avatar_path = self._managed_avatar_path(record.avatar)
+        self._character_path(character_id).unlink(missing_ok=True)
+        if avatar_path is not None and avatar_path.is_file():
+            avatar_path.unlink(missing_ok=True)
+
+    async def save_avatar(self, character_id: str, file: UploadFile) -> CharacterRecord:
+        """Validate and store an uploaded avatar for a character."""
+
+        current = self.get_character(character_id)
+        extension = self._resolve_avatar_extension(file)
+        payload = await file.read()
+
+        if not payload:
+            raise AvatarValidationError("Avatar file cannot be empty")
+        if len(payload) > MAX_AVATAR_SIZE_BYTES:
+            raise AvatarValidationError("Avatar file size must be smaller than 2MB")
+
+        filename = f"{character_id}-{uuid4().hex[:8]}{extension}"
+        target_path = self.avatar_dir / filename
+        target_path.write_bytes(payload)
+
+        old_avatar_path = self._managed_avatar_path(current.avatar)
+        if old_avatar_path is not None and old_avatar_path.is_file():
+            old_avatar_path.unlink(missing_ok=True)
+
+        record = CharacterRecord(
+            character_id=current.character_id,
+            name=current.name,
+            avatar=filename,
+            greeting=current.greeting,
+            description=current.description,
+            system_prompt=current.system_prompt,
+            created_at=current.created_at,
+            updated_at=_now_iso_z(),
+            managed_by=current.managed_by,
+        )
+        self._write_character(record)
+        return record
+
+    def build_avatar_url(self, avatar: str | None, base_url: str) -> str | None:
+        """Build an absolute backend avatar URL for managed avatars."""
+
+        managed_path = self._managed_avatar_path(avatar)
+        if avatar is None or managed_path is None or not managed_path.is_file():
+            return None
+
+        return f"{base_url.rstrip('/')}/api/assets/avatars/{avatar}"
+
+    def _character_path(self, character_id: str) -> Path:
+        return self.persona_dir / f"{character_id}.md"
+
+    def _record_from_persona(self, persona: Persona) -> CharacterRecord:
+        return CharacterRecord(
+            character_id=persona.character_id,
+            name=persona.name,
+            avatar=persona.avatar,
+            greeting=persona.greeting,
+            description=persona.description,
+            system_prompt=persona.system_prompt,
+            created_at=persona.created_at,
+            updated_at=persona.updated_at,
+            managed_by=persona.managed_by,
+        )
+
+    def _ensure_unique_name(self, name: str, ignore_character_id: str | None = None) -> None:
+        for record in self.list_characters():
+            if ignore_character_id is not None and record.character_id == ignore_character_id:
+                continue
+            if record.name.casefold() == name.casefold():
+                raise CharacterNameConflictError(f"Character name '{name}' already exists")
+
+    def _resolve_character_id(self, requested_id: str | None, name: str) -> str:
+        raw_id = requested_id.strip() if requested_id else name
+        base_id = _slugify_character_id(raw_id)
+        if not base_id:
+            base_id = f"character-{uuid4().hex[:8]}"
+
+        candidate = base_id
+        suffix = 2
+        while self._character_path(candidate).exists():
+            candidate = f"{base_id}-{suffix}"
+            suffix += 1
+        return candidate
+
+    def _write_character(self, record: CharacterRecord) -> None:
+        metadata = {
+            "name": record.name,
+            "avatar": record.avatar,
+            "greeting": record.greeting,
+            "description": record.description,
+            "created_at": record.created_at,
+            "updated_at": record.updated_at,
+            "managed_by": record.managed_by,
+        }
+        clean_metadata = {key: value for key, value in metadata.items() if value is not None}
+        frontmatter = yaml.safe_dump(clean_metadata, allow_unicode=True, sort_keys=False).strip()
+        body = record.system_prompt.strip()
+        content = f"---\n{frontmatter}\n---\n\n{body}\n"
+        self._character_path(record.character_id).write_text(content, encoding="utf-8")
+
+    def _resolve_avatar_extension(self, file: UploadFile) -> str:
+        content_type = file.content_type or ""
+        if content_type in ALLOWED_AVATAR_CONTENT_TYPES:
+            return ALLOWED_AVATAR_CONTENT_TYPES[content_type]
+
+        filename = file.filename or ""
+        extension = Path(filename).suffix.lower()
+        if extension in {".png", ".jpg", ".jpeg", ".webp"}:
+            return ".jpg" if extension == ".jpeg" else extension
+
+        raise AvatarValidationError("Only PNG/JPG/WEBP avatars are supported")
+
+    def _managed_avatar_path(self, avatar: str | None) -> Path | None:
+        if not avatar:
+            return None
+
+        path = self.avatar_dir / avatar
+        return path if path.parent == self.avatar_dir else None

--- a/src/storage/character_storage.py
+++ b/src/storage/character_storage.py
@@ -20,6 +20,30 @@ ALLOWED_AVATAR_CONTENT_TYPES = {
     "image/jpeg": ".jpg",
     "image/webp": ".webp",
 }
+WINDOWS_RESERVED_FILENAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    "COM1",
+    "COM2",
+    "COM3",
+    "COM4",
+    "COM5",
+    "COM6",
+    "COM7",
+    "COM8",
+    "COM9",
+    "LPT1",
+    "LPT2",
+    "LPT3",
+    "LPT4",
+    "LPT5",
+    "LPT6",
+    "LPT7",
+    "LPT8",
+    "LPT9",
+}
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 _DEFAULT_PERSONA_DIR = _PROJECT_ROOT / "prompts" / "persona"
@@ -81,10 +105,27 @@ def _now_iso_z() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
-def _slugify_character_id(value: str) -> str:
-    normalized = re.sub(r"[^a-z0-9]+", "-", value.strip().lower())
-    normalized = normalized.strip("-")
+def _normalize_character_id(value: str) -> str:
+    """Normalize user-facing names into filesystem-safe custom IDs.
+
+    保留 Unicode 名称本身，仅移除 Windows 不允许的文件名字符。
+    """
+    normalized = re.sub(r'[<>:"/\\|?*\x00-\x1f]+', "-", value.strip())
+    normalized = re.sub(r"\s+", " ", normalized).strip(" .")
+    if normalized.upper() in WINDOWS_RESERVED_FILENAMES:
+        normalized = f"{normalized}_"
     return normalized
+
+
+def _validate_custom_character_name(name: str) -> None:
+    """Validate custom character names for safe filename generation.
+
+    允许任意语言的字母与数字，但不允许空格、标点和特殊符号。
+    """
+    if not name or any(not char.isalnum() for char in name):
+        raise CharacterStorageError(
+            "Character name may contain only letters and digits, without spaces or symbols"
+        )
 
 
 class CharacterStorage:
@@ -134,6 +175,7 @@ class CharacterStorage:
         if not clean_system_prompt:
             raise CharacterStorageError("System prompt cannot be empty")
 
+        _validate_custom_character_name(clean_name)
         self._ensure_unique_name(clean_name)
         resolved_id = self._resolve_character_id(character_id, clean_name)
         now = _now_iso_z()
@@ -177,6 +219,8 @@ class CharacterStorage:
         if not next_system_prompt:
             raise CharacterStorageError("System prompt cannot be empty")
 
+        if not current.is_system:
+            _validate_custom_character_name(next_name)
         self._ensure_unique_name(next_name, ignore_character_id=character_id)
 
         record = CharacterRecord(
@@ -275,7 +319,7 @@ class CharacterStorage:
 
     def _resolve_character_id(self, requested_id: str | None, name: str) -> str:
         raw_id = requested_id.strip() if requested_id else name
-        base_id = _slugify_character_id(raw_id)
+        base_id = _normalize_character_id(raw_id)
         if not base_id:
             base_id = f"character-{uuid4().hex[:8]}"
 

--- a/tests/routes/test_characters.py
+++ b/tests/routes/test_characters.py
@@ -1,76 +1,250 @@
-"""
-Tests for character management REST API.
-角色管理 REST API 测试。
-"""
+"""Tests for Phase 7 character management routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 
 from src.app import create_app
+from src.storage.character_storage import CharacterStorage
 from src.utils.config_loader import load_config
 
 
+def _write_persona(
+    path: Path,
+    *,
+    name: str,
+    avatar: str | None,
+    greeting: str | None,
+    description: str | None,
+    system_prompt: str,
+    created_at: str | None = None,
+    updated_at: str | None = None,
+    managed_by: str | None = None,
+) -> None:
+    metadata: dict[str, str] = {"name": name}
+    if avatar is not None:
+        metadata["avatar"] = avatar
+    if greeting is not None:
+        metadata["greeting"] = greeting
+    if description is not None:
+        metadata["description"] = description
+    if created_at is not None:
+        metadata["created_at"] = created_at
+    if updated_at is not None:
+        metadata["updated_at"] = updated_at
+    if managed_by is not None:
+        metadata["managed_by"] = managed_by
+
+    lines = ["---"]
+    lines.extend(f"{key}: {value}" for key, value in metadata.items())
+    lines.extend(["---", "", system_prompt, ""])
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
 @pytest_asyncio.fixture
-async def client():
-    """Create test client. / 创建测试客户端。"""
+async def client_and_storage(tmp_path: Path):
+    """Create test client with isolated character storage."""
+
+    persona_dir = tmp_path / "persona"
+    avatar_dir = tmp_path / "avatars"
+    persona_dir.mkdir(parents=True, exist_ok=True)
+
+    _write_persona(
+        persona_dir / "atri.md",
+        name="亚托莉",
+        avatar="atri.jpg",
+        greeting="主人，早上好！",
+        description="默认角色",
+        system_prompt="你是亚托莉。",
+    )
+    _write_persona(
+        persona_dir / "bilibili.md",
+        name="御坂美琴",
+        avatar="bilibili.jpg",
+        greeting="今天也要加油。",
+        description="备用角色",
+        system_prompt="你是御坂美琴。",
+    )
+
     config = load_config("config.yaml")
     app = create_app(config)
+    storage = CharacterStorage(persona_dir=persona_dir, avatar_dir=avatar_dir)
+    app.state.character_storage = storage
+
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
-        yield ac
+        yield ac, storage
 
 
 @pytest.mark.asyncio
-async def test_list_characters_returns_at_least_one(client: AsyncClient):
-    """List should return at least 1 character (atri). / 列表应至少返回 1 个角色（atri）。"""
+async def test_list_characters_returns_existing_personas(client_and_storage):
+    client, _storage = client_and_storage
+
     response = await client.get("/api/characters")
     assert response.status_code == 200
 
     data = response.json()
     assert isinstance(data, list)
-    assert len(data) >= 1
-
-    # Check atri exists
-    atri = next((c for c in data if c["character_id"] == "atri"), None)
-    assert atri is not None
-    assert "name" in atri
-    assert "avatar" in atri
-    assert "greeting" in atri
+    assert {item["character_id"] for item in data} == {"atri", "bilibili"}
+    assert all("system_prompt" not in item for item in data)
+    assert all(item["is_system"] is True for item in data)
 
 
 @pytest.mark.asyncio
-async def test_list_characters_excludes_system_prompt(client: AsyncClient):
-    """List should not include system_prompt. / 列表不应包含 system_prompt。"""
-    response = await client.get("/api/characters")
-    assert response.status_code == 200
+async def test_get_character_returns_full_fields(client_and_storage):
+    client, _storage = client_and_storage
 
-    data = response.json()
-    for character in data:
-        assert "system_prompt" not in character
-
-
-@pytest.mark.asyncio
-async def test_get_character_returns_full_fields(client: AsyncClient):
-    """Detail should return all fields including system_prompt.
-
-    详情应返回所有字段（含 system_prompt）。
-    """
     response = await client.get("/api/characters/atri")
     assert response.status_code == 200
 
     data = response.json()
     assert data["character_id"] == "atri"
-    assert "name" in data
-    assert "avatar" in data
-    assert "greeting" in data
-    assert "system_prompt" in data
-    assert isinstance(data["system_prompt"], str)
-    assert len(data["system_prompt"]) > 0
+    assert data["name"] == "亚托莉"
+    assert data["avatar"] == "atri.jpg"
+    assert data["description"] == "默认角色"
+    assert data["system_prompt"] == "你是亚托莉。"
+    assert data["avatar_url"] is None
+    assert data["is_system"] is True
 
 
 @pytest.mark.asyncio
-async def test_get_nonexistent_character_returns_404(client: AsyncClient):
-    """Nonexistent character should return 404. / 不存在的角色应返回 404。"""
-    response = await client.get("/api/characters/nonexistent")
-    assert response.status_code == 404
-    assert "not found" in response.json()["detail"].lower()
+async def test_create_character_persists_markdown_file(client_and_storage):
+    client, storage = client_and_storage
+
+    response = await client.post(
+        "/api/characters",
+        json={
+            "name": "Phase7 Card",
+            "greeting": "你好，我是新角色。",
+            "description": "Phase 7 创建的角色",
+            "system_prompt": "你是 Phase 7 新角色。",
+        },
+    )
+    assert response.status_code == 201
+
+    data = response.json()
+    assert data["character_id"] == "phase7-card"
+    assert data["is_system"] is False
+    assert data["description"] == "Phase 7 创建的角色"
+    assert data["created_at"] is not None
+    assert storage.get_character("phase7-card").managed_by == "atri"
+    assert (storage.persona_dir / "phase7-card.md").is_file()
+
+
+@pytest.mark.asyncio
+async def test_update_character_changes_metadata(client_and_storage):
+    client, _storage = client_and_storage
+
+    create_response = await client.post(
+        "/api/characters",
+        json={
+            "name": "Editable Card",
+            "greeting": "初始问候",
+            "description": "初始描述",
+            "system_prompt": "初始设定",
+        },
+    )
+    created = create_response.json()
+
+    update_response = await client.put(
+        f"/api/characters/{created['character_id']}",
+        json={
+            "name": "Editable Card Updated",
+            "greeting": "更新后的问候",
+            "description": "更新后的描述",
+            "system_prompt": "更新后的设定",
+        },
+    )
+    assert update_response.status_code == 200
+
+    updated = update_response.json()
+    assert updated["name"] == "Editable Card Updated"
+    assert updated["greeting"] == "更新后的问候"
+    assert updated["description"] == "更新后的描述"
+    assert updated["system_prompt"] == "更新后的设定"
+    assert updated["updated_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_delete_character_removes_custom_persona_file(client_and_storage):
+    client, storage = client_and_storage
+
+    create_response = await client.post(
+        "/api/characters",
+        json={
+            "name": "Disposable Card",
+            "greeting": "待删除",
+            "description": "待删除角色",
+            "system_prompt": "删除测试",
+        },
+    )
+    created = create_response.json()
+
+    delete_response = await client.delete(f"/api/characters/{created['character_id']}")
+    assert delete_response.status_code == 204
+    assert not (storage.persona_dir / f"{created['character_id']}.md").exists()
+
+    get_response = await client.get(f"/api/characters/{created['character_id']}")
+    assert get_response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_system_character_returns_400(client_and_storage):
+    client, _storage = client_and_storage
+
+    response = await client.delete("/api/characters/atri")
+    assert response.status_code == 400
+    assert "protected system character" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_character_rejects_duplicate_name(client_and_storage):
+    client, _storage = client_and_storage
+
+    response = await client.post(
+        "/api/characters",
+        json={
+            "name": "亚托莉",
+            "greeting": "重复",
+            "description": "重复名称",
+            "system_prompt": "重复名称测试",
+        },
+    )
+    assert response.status_code == 400
+    assert "already exists" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_upload_avatar_stores_file_and_updates_character(client_and_storage):
+    client, storage = client_and_storage
+
+    create_response = await client.post(
+        "/api/characters",
+        json={
+            "name": "Avatar Card",
+            "greeting": "头像测试",
+            "description": "测试头像上传",
+            "system_prompt": "头像测试角色",
+        },
+    )
+    created = create_response.json()
+
+    upload_response = await client.post(
+        f"/api/characters/{created['character_id']}/avatar",
+        files={"avatar": ("avatar.png", b"fake-image-content", "image/png")},
+    )
+    assert upload_response.status_code == 200
+
+    payload = upload_response.json()
+    assert payload["character_id"] == created["character_id"]
+    assert payload["avatar"].endswith(".png")
+    assert payload["avatar_url"].startswith("http://test/api/assets/avatars/")
+    assert (storage.avatar_dir / payload["avatar"]).is_file()
+
+    detail_response = await client.get(f"/api/characters/{created['character_id']}")
+    detail = detail_response.json()
+    assert detail["avatar"] == payload["avatar"]
+    assert detail["avatar_url"] == payload["avatar_url"]

--- a/tests/routes/test_characters.py
+++ b/tests/routes/test_characters.py
@@ -117,7 +117,7 @@ async def test_create_character_persists_markdown_file(client_and_storage):
     response = await client.post(
         "/api/characters",
         json={
-            "name": "Phase7 Card",
+            "name": "测试",
             "greeting": "你好，我是新角色。",
             "description": "Phase 7 创建的角色",
             "system_prompt": "你是 Phase 7 新角色。",
@@ -126,12 +126,12 @@ async def test_create_character_persists_markdown_file(client_and_storage):
     assert response.status_code == 201
 
     data = response.json()
-    assert data["character_id"] == "phase7-card"
+    assert data["character_id"] == "测试"
     assert data["is_system"] is False
     assert data["description"] == "Phase 7 创建的角色"
     assert data["created_at"] is not None
-    assert storage.get_character("phase7-card").managed_by == "atri"
-    assert (storage.persona_dir / "phase7-card.md").is_file()
+    assert storage.get_character("测试").managed_by == "atri"
+    assert (storage.persona_dir / "测试.md").is_file()
 
 
 @pytest.mark.asyncio
@@ -141,7 +141,7 @@ async def test_update_character_changes_metadata(client_and_storage):
     create_response = await client.post(
         "/api/characters",
         json={
-            "name": "Editable Card",
+            "name": "EditableCard",
             "greeting": "初始问候",
             "description": "初始描述",
             "system_prompt": "初始设定",
@@ -152,7 +152,7 @@ async def test_update_character_changes_metadata(client_and_storage):
     update_response = await client.put(
         f"/api/characters/{created['character_id']}",
         json={
-            "name": "Editable Card Updated",
+            "name": "EditableCardUpdated",
             "greeting": "更新后的问候",
             "description": "更新后的描述",
             "system_prompt": "更新后的设定",
@@ -161,7 +161,7 @@ async def test_update_character_changes_metadata(client_and_storage):
     assert update_response.status_code == 200
 
     updated = update_response.json()
-    assert updated["name"] == "Editable Card Updated"
+    assert updated["name"] == "EditableCardUpdated"
     assert updated["greeting"] == "更新后的问候"
     assert updated["description"] == "更新后的描述"
     assert updated["system_prompt"] == "更新后的设定"
@@ -175,7 +175,7 @@ async def test_delete_character_removes_custom_persona_file(client_and_storage):
     create_response = await client.post(
         "/api/characters",
         json={
-            "name": "Disposable Card",
+            "name": "DisposableCard",
             "greeting": "待删除",
             "description": "待删除角色",
             "system_prompt": "删除测试",
@@ -218,13 +218,63 @@ async def test_create_character_rejects_duplicate_name(client_and_storage):
 
 
 @pytest.mark.asyncio
+async def test_create_character_rejects_symbol_name(client_and_storage):
+    client, _storage = client_and_storage
+
+    response = await client.post(
+        "/api/characters",
+        json={
+            "name": "测试!",
+            "greeting": "非法名称",
+            "description": "非法名称",
+            "system_prompt": "非法名称测试",
+        },
+    )
+    assert response.status_code == 400
+    assert "only letters and digits, without spaces or symbols" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_character_allows_multilingual_letters_and_digits(client_and_storage):
+    client, storage = client_and_storage
+
+    response = await client.post(
+        "/api/characters",
+        json={
+            "name": "テスト2",
+            "greeting": "多语言测试",
+            "description": "允许日文和数字",
+            "system_prompt": "你是多语言测试角色。",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["character_id"] == "テスト2"
+    assert (storage.persona_dir / "テスト2.md").is_file()
+
+    response = await client.post(
+        "/api/characters",
+        json={
+            "name": "Тест3",
+            "greeting": "俄文测试",
+            "description": "允许俄文和数字",
+            "system_prompt": "你是俄文测试角色。",
+        },
+    )
+    assert response.status_code == 201
+    data = response.json()
+    assert data["character_id"] == "Тест3"
+    assert (storage.persona_dir / "Тест3.md").is_file()
+
+
+@pytest.mark.asyncio
 async def test_upload_avatar_stores_file_and_updates_character(client_and_storage):
     client, storage = client_and_storage
 
     create_response = await client.post(
         "/api/characters",
         json={
-            "name": "Avatar Card",
+            "name": "AvatarCard",
             "greeting": "头像测试",
             "description": "测试头像上传",
             "system_prompt": "头像测试角色",

--- a/tests/routes/test_chats.py
+++ b/tests/routes/test_chats.py
@@ -126,6 +126,66 @@ async def test_create_chat_truncates_long_fallback(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_create_chat_with_deferred_title_uses_first_sentence_excerpt(client: AsyncClient):
+    """Deferred title mode should return the first sentence's first 8 chars."""
+
+    async def mock_stream(*args, **kwargs):
+        yield "真正标题"
+
+    with patch("src.routes.chats.create_from_role") as mock_create:
+        mock_llm = MagicMock()
+        mock_llm.chat_completion_stream = MagicMock(
+            side_effect=lambda *a, **kw: mock_stream(*a, **kw)
+        )
+        mock_create.return_value = mock_llm
+
+        response = await client.post(
+            "/api/chats",
+            json={
+                "character_id": "atri",
+                "first_message": "你好呀亚托莉。今天一起散步吧！",
+                "defer_title": True,
+            },
+        )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["title"] == "你好呀亚托莉"
+
+
+@pytest.mark.asyncio
+async def test_create_chat_with_deferred_title_backfills_generated_title(client: AsyncClient):
+    """Deferred title mode should patch the stored title in the background."""
+
+    async def mock_stream(*args, **kwargs):
+        yield "延后生成标题"
+
+    with patch("src.routes.chats.create_from_role") as mock_create:
+        mock_llm = MagicMock()
+        mock_llm.chat_completion_stream = MagicMock(
+            side_effect=lambda *a, **kw: mock_stream(*a, **kw)
+        )
+        mock_create.return_value = mock_llm
+
+        create_response = await client.post(
+            "/api/chats",
+            json={
+                "character_id": "atri",
+                "first_message": "晚上一起看海吧。顺便聊聊心情。",
+                "defer_title": True,
+            },
+        )
+
+    assert create_response.status_code == 201
+    create_data = create_response.json()
+    assert create_data["title"] == "晚上一起看海吧"
+
+    detail_response = await client.get(f"/api/chats/{create_data['id']}")
+    assert detail_response.status_code == 200
+    assert detail_response.json()["metadata"]["title"] == "延后生成标题"
+
+
+@pytest.mark.asyncio
 async def test_list_chats_empty(client: AsyncClient):
     """List chats should return empty list for new user.
     新用户列出聊天应返回空列表。

--- a/uv.lock
+++ b/uv.lock
@@ -49,6 +49,7 @@ dependencies = [
     { name = "mem0ai" },
     { name = "openai" },
     { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -70,6 +71,7 @@ requires-dist = [
     { name = "mem0ai", specifier = ">=2.0.0" },
     { name = "openai", specifier = ">=2.32.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "uvicorn", specifier = ">=0.44.0" },
     { name = "websockets", specifier = ">=16.0" },
@@ -1032,6 +1034,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add custom character CRUD and backend avatar storage for Phase 7
- support deferred chat title generation with temporary titles and async backfill
- use custom character names as default ids while restricting custom names to letters and digits

## Testing
- uv run ruff check src/storage/character_storage.py tests/routes/test_characters.py
- uv run python -m mypy src/ --ignore-missing-imports
- uv run pytest tests/routes/test_characters.py -v
- uv run ruff check src/routes/chats.py tests/routes/test_chats.py
- uv run pytest tests/routes/test_chats.py -v