### PR TITLE
feat: implement Phase 9 ASR backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .omc
 .idea
-data/chats/default/
+
 # Python
 __pycache__/
 *.pyc
@@ -23,6 +23,11 @@ data/characters/**/sessions/
 data/characters/**/short_term_memory.json
 data/qdrant/
 
+data/chats/**/sessions/
+data/chats/**/short_term_memory.json
+data/chats/**/index.json
+
+data/avatars/
 # Env files
 .env
 .env.*

--- a/config.yaml
+++ b/config.yaml
@@ -21,8 +21,8 @@ llm_config: config/llm_config.yaml
 memory_config: config/memory_config.yaml
 server_config: config/server_config.yaml
 storage_config: config/storage_config.yaml
+asr_config: config/asr_config.yaml
 
 # Reserved for future phases:
-# asr_config: config/asr_config.yaml
 # tts_config: config/tts_config.yaml
 # translate_config: config/translate_config.yaml

--- a/config/asr_config.yaml
+++ b/config/asr_config.yaml
@@ -1,6 +1,34 @@
-# ============================================================
-# ASR config -- RESERVED
-#
-# Filled in during the ASR implementation phase.
-# Reference: docs/项目架构设计.md §2.1 (Input Layer)
-# ============================================================
+asr_model: web_speech_api
+auto_send:
+  enabled: false
+  delay_ms: 2000
+web_speech_api:
+  language: zh-CN
+  continuous: true
+  interim_results: true
+  max_alternatives: 1
+faster_whisper:
+  model_path: distil-medium.en
+  download_root: models/whisper
+  language: en
+  device: auto
+  compute_type: int8
+  prompt: ''
+whisper_cpp:
+  model_name: small
+  model_dir: models/whisper
+  print_realtime: false
+  print_progress: false
+  language: auto
+  prompt: ''
+whisper:
+  name: medium
+  download_root: models/whisper
+  device: cpu
+  prompt: ''
+openai_whisper:
+  model: whisper-1
+  api_key: ${OPENAI_API_KEY}
+  base_url: ''
+  language: ''
+  prompt: ''

--- a/docs/ASR配置说明.md
+++ b/docs/ASR配置说明.md
@@ -1,0 +1,497 @@
+# ASR 配置说明
+
+> **适用范围**: Phase 9 ASR 语音输入  
+> **配置文件**: `atri/config/asr_config.yaml`  
+> **设置页面**: `atri-webui` 的 `/settings/modules/hearing`  
+> **最后更新**: 2026-04-25
+
+本文说明 ASR（Automatic Speech Recognition，自动语音识别）的配置结构、Provider 选择、前端设置页对应关系和常见排障方法。
+
+---
+
+## 1. 快速开始
+
+默认配置使用浏览器内置的 Web Speech API。它不需要后端模型，也不需要 API Key。
+
+```yaml
+asr_model: web_speech_api
+auto_send:
+  enabled: false
+  delay_ms: 2000
+```
+
+启动后打开前端：
+
+```text
+/settings/modules/hearing
+```
+
+你可以在该页面完成以下操作：
+
+- 选择麦克风输入设备
+- 切换 ASR Provider
+- 配置识别语言、模型和路径
+- 测试语音转文字
+- 配置转写后是否自动发送到聊天
+
+---
+
+## 2. 配置加载方式
+
+根配置文件 `atri/config.yaml` 通过下面的入口引用 ASR 配置：
+
+```yaml
+asr_config: config/asr_config.yaml
+```
+
+后端 `config_loader` 会把它加载到运行时配置的 `asr` 节点下：
+
+```python
+config["asr"]
+```
+
+因此 ASR 模块实际读取的是：
+
+```text
+atri/config/asr_config.yaml -> runtime config["asr"]
+```
+
+---
+
+## 3. 顶层配置结构
+
+当前配置采用 Open-LLM-VTuber 风格：`asr_model` 指定当前 Provider，Provider 参数使用同名顶层块保存。
+
+```yaml
+asr_model: web_speech_api
+auto_send:
+  enabled: false
+  delay_ms: 2000
+
+web_speech_api:
+  language: zh-CN
+  continuous: true
+  interim_results: true
+  max_alternatives: 1
+
+faster_whisper:
+  model_path: distil-medium.en
+  download_root: models/whisper
+  language: en
+  device: auto
+  compute_type: int8
+  prompt: ''
+
+whisper_cpp:
+  model_name: small
+  model_dir: models/whisper
+  print_realtime: false
+  print_progress: false
+  language: auto
+  prompt: ''
+
+openai_whisper:
+  model: whisper-1
+  api_key: ${OPENAI_API_KEY}
+  base_url: ''
+  language: ''
+  prompt: ''
+```
+
+### 顶层字段
+
+| 字段 | 类型 | 说明 |
+| --- | --- | --- |
+| `asr_model` | string | 当前启用的 ASR Provider 名称。 |
+| `auto_send.enabled` | boolean | 转写完成后是否自动发送到聊天输入链路。默认关闭。 |
+| `auto_send.delay_ms` | number | 自动发送延迟，单位毫秒。默认 `2000`。 |
+
+当前可选的 `asr_model`：
+
+| Provider | 类型 | 后端转写 | 浏览器流式 | 说明 |
+| --- | --- | --- | --- | --- |
+| `web_speech_api` | 浏览器 | 否 | 是 | 使用浏览器 SpeechRecognition。默认推荐。 |
+| `faster_whisper` | 本地 | 是 | 否 | 本地 faster-whisper，参考 OLV 链路。 |
+| `whisper_cpp` | 本地 | 是 | 否 | 本地 pywhispercpp，参考 OLV 链路。 |
+| `openai_whisper` | 云服务 | 是 | 否 | OpenAI-compatible 音频转写。 |
+
+`whisper` 配置块目前保留给 OLV 兼容和后续扩展。Phase 9 当前没有注册 `whisper` Provider，不要把 `asr_model` 设置为 `whisper`。
+
+---
+
+## 4. Provider 配置
+
+### 4.1 `web_speech_api`
+
+浏览器端语音识别 Provider。后端只保存配置和状态，不接收音频转写。
+
+```yaml
+asr_model: web_speech_api
+web_speech_api:
+  language: zh-CN
+  continuous: true
+  interim_results: true
+  max_alternatives: 1
+```
+
+| 字段 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `language` | string | `zh-CN` | 浏览器识别语言。常用值：`zh-CN`、`en-US`、`ja-JP`。 |
+| `continuous` | boolean | `true` | 是否持续监听。 |
+| `interim_results` | boolean | `true` | 是否返回临时识别结果。 |
+| `max_alternatives` | number | `1` | 浏览器返回的候选结果数量。 |
+
+使用建议：
+
+- Chrome、Edge、Safari 对 Web Speech API 支持较好。
+- Firefox 通常不可用或支持有限。
+- 该 Provider 不需要 Python 依赖和模型文件。
+
+### 4.2 `faster_whisper`
+
+本地 faster-whisper Provider。适合本地离线转写。
+
+```yaml
+asr_model: faster_whisper
+faster_whisper:
+  model_path: distil-medium.en
+  download_root: models/whisper
+  language: en
+  device: auto
+  compute_type: int8
+  prompt: ''
+```
+
+| 字段 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `model_path` | string | `distil-medium.en` | 模型名称、本地路径或 Hugging Face 模型 ID。 |
+| `download_root` | string | `models/whisper` | 模型下载和缓存目录。 |
+| `language` | string | `en` | 识别语言。空字符串或 `auto` 表示自动检测。 |
+| `device` | string | `auto` | 推理设备。常用值：`auto`、`cpu`、`cuda`。 |
+| `compute_type` | string | `int8` | 推理精度。CPU 常用 `int8`。 |
+| `prompt` | string | `''` | 初始提示词，可改善专有名词识别。 |
+
+依赖说明：
+
+```powershell
+cd D:\Coding\GitHub_Resuorse\emotion-robot\atri
+uv add faster-whisper
+```
+
+如果依赖或模型不可用，Provider 会显示为 unavailable，不会阻止后端启动。
+
+### 4.3 `whisper_cpp`
+
+本地 whisper.cpp Provider，使用 `pywhispercpp`。
+
+```yaml
+asr_model: whisper_cpp
+whisper_cpp:
+  model_name: small
+  model_dir: models/whisper
+  print_realtime: false
+  print_progress: false
+  language: auto
+  prompt: ''
+```
+
+| 字段 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `model_name` | string | `small` | pywhispercpp 模型名。常用值：`tiny`、`base`、`small`、`medium`。 |
+| `model_dir` | string | `models/whisper` | 模型目录。 |
+| `print_realtime` | boolean | `false` | 是否打印实时片段。 |
+| `print_progress` | boolean | `false` | 是否打印进度。 |
+| `language` | string | `auto` | 识别语言。 |
+| `prompt` | string | `''` | 初始提示词。 |
+
+依赖说明：
+
+```powershell
+cd D:\Coding\GitHub_Resuorse\emotion-robot\atri
+uv add pywhispercpp
+```
+
+### 4.4 `openai_whisper`
+
+OpenAI-compatible 云端转写 Provider。
+
+```yaml
+asr_model: openai_whisper
+openai_whisper:
+  model: whisper-1
+  api_key: ${OPENAI_API_KEY}
+  base_url: ''
+  language: ''
+  prompt: ''
+```
+
+| 字段 | 类型 | 默认值 | 说明 |
+| --- | --- | --- | --- |
+| `model` | string | `whisper-1` | 转写模型名。 |
+| `api_key` | string | `${OPENAI_API_KEY}` | API Key。必须使用环境变量占位符。 |
+| `base_url` | string | `''` | OpenAI-compatible endpoint。空字符串使用 SDK 默认值。 |
+| `language` | string | `''` | 识别语言。空字符串表示自动检测。 |
+| `prompt` | string | `''` | 初始提示词。 |
+
+依赖说明：
+
+```powershell
+cd D:\Coding\GitHub_Resuorse\emotion-robot\atri
+uv add openai
+```
+
+环境变量示例：
+
+```powershell
+$env:OPENAI_API_KEY = "YOUR_API_KEY"
+```
+
+不要把真实 API Key 写进 `asr_config.yaml`。
+
+---
+
+## 5. 敏感配置规则
+
+ASR 配置支持 `${ENV_NAME}` 环境变量占位符。`api_key` 等敏感字段必须使用占位符。
+
+正确：
+
+```yaml
+openai_whisper:
+  api_key: ${OPENAI_API_KEY}
+```
+
+错误：
+
+```yaml
+openai_whisper:
+  api_key: sk-真实密钥
+```
+
+后端有两层保护：
+
+- 运行时可以读取环境变量展开后的值。
+- 保存 YAML 时会尽量保留占位符，不把运行时密钥写回配置文件。
+- API 返回配置时会把 `api_key`、`token`、`secret`、`password` mask 成 `********`。
+
+如果你发现真实 key 被写入配置文件，请立即：
+
+1. 删除该 key，改回 `${OPENAI_API_KEY}`。
+2. 轮换服务商后台的 API Key。
+3. 扫描仓库，确认没有残留明文密钥。
+
+---
+
+## 6. 前端设置页对应关系
+
+设置页路径：
+
+```text
+/settings/modules/hearing
+```
+
+页面区域和配置关系：
+
+| 页面区域 | 对应配置 | 说明 |
+| --- | --- | --- |
+| Audio Input Device | 浏览器 localStorage | 选择麦克风设备。 |
+| Providers | `asr_model` | 切换当前 Provider。 |
+| Web Speech API 设置 | `web_speech_api` | 配置浏览器识别语言和临时结果。 |
+| Faster Whisper 设置 | `faster_whisper` | 配置模型、语言和下载目录。 |
+| Whisper.cpp 设置 | `whisper_cpp` | 配置模型名和模型目录。 |
+| OpenAI Whisper 设置 | `openai_whisper` | 配置模型和 base URL。 |
+| Auto-send Settings | `auto_send` | 控制转写后是否自动发送。 |
+| Audio Monitor | 不落盘 | 测试麦克风音量和语音阈值。 |
+| Transcription | 当前 Provider | 测试语音转文字链路。 |
+
+---
+
+## 7. 运行链路
+
+### `web_speech_api`
+
+```text
+浏览器麦克风
+  -> SpeechRecognition
+  -> 前端得到 transcript
+  -> 填入聊天输入框
+  -> 用户手动发送，或按 auto_send 规则发送
+```
+
+后端不接收音频文件。
+
+### 后端 Provider
+
+适用于 `faster_whisper`、`whisper_cpp`、`openai_whisper`。
+
+```text
+浏览器麦克风
+  -> MediaRecorder
+  -> POST /api/asr/transcribe
+  -> ASRService
+  -> Provider 转写
+  -> 返回 transcript
+  -> 前端填入聊天输入框
+```
+
+---
+
+## 8. API 端点
+
+| 方法 | 路径 | 说明 |
+| --- | --- | --- |
+| `GET` | `/api/asr/providers` | 获取 Provider 列表、可用性和当前配置。 |
+| `GET` | `/api/asr/config` | 获取当前 ASR 配置。敏感值会被 mask。 |
+| `PUT` | `/api/asr/config` | 合并保存 ASR 配置。 |
+| `POST` | `/api/asr/switch` | 切换当前 Provider。 |
+| `GET` | `/api/asr/health` | 获取 ASR 健康状态。 |
+| `POST` | `/api/asr/transcribe` | 上传音频并转写。仅后端 Provider 支持。 |
+
+切换 Provider 示例：
+
+```powershell
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://127.0.0.1:8430/api/asr/switch" `
+  -ContentType "application/json" `
+  -Body '{"provider":"web_speech_api"}'
+```
+
+---
+
+## 9. 常见配置示例
+
+### 示例 A：中文浏览器识别
+
+```yaml
+asr_model: web_speech_api
+web_speech_api:
+  language: zh-CN
+  continuous: true
+  interim_results: true
+  max_alternatives: 1
+auto_send:
+  enabled: false
+  delay_ms: 2000
+```
+
+适合快速验证。推荐作为默认配置。
+
+### 示例 B：本地 faster-whisper 英文识别
+
+```yaml
+asr_model: faster_whisper
+faster_whisper:
+  model_path: distil-medium.en
+  download_root: models/whisper
+  language: en
+  device: auto
+  compute_type: int8
+  prompt: ''
+```
+
+适合离线英文转写。
+
+### 示例 C：本地 whisper.cpp 自动语言识别
+
+```yaml
+asr_model: whisper_cpp
+whisper_cpp:
+  model_name: small
+  model_dir: models/whisper
+  print_realtime: false
+  print_progress: false
+  language: auto
+  prompt: ''
+```
+
+适合轻量本地转写。
+
+### 示例 D：云端 OpenAI-compatible 转写
+
+```yaml
+asr_model: openai_whisper
+openai_whisper:
+  model: whisper-1
+  api_key: ${OPENAI_API_KEY}
+  base_url: ''
+  language: ''
+  prompt: ''
+```
+
+适合不想在本地加载模型的场景。
+
+---
+
+## 10. 自检命令
+
+后端 ASR 测试：
+
+```powershell
+cd D:\Coding\GitHub_Resuorse\emotion-robot\atri
+uv run ruff check src tests/routes/test_asr.py
+uv run python -m mypy src/ --ignore-missing-imports
+uv run pytest tests/routes/test_asr.py -v
+```
+
+前端检查：
+
+```powershell
+cd D:\Coding\GitHub_Resuorse\emotion-robot\atri-webui
+npm run type-check
+npm run build
+```
+
+---
+
+## 11. 常见问题
+
+### Provider 显示 unavailable
+
+原因通常是依赖未安装、模型路径错误或 API Key 未配置。
+
+处理方式：
+
+1. 查看 `/settings/modules/hearing` 中 Provider 卡片的状态提示。
+2. 确认对应 Python 包已安装。
+3. 确认模型目录或环境变量正确。
+
+### Web Speech API 不可用
+
+原因通常是浏览器不支持 `SpeechRecognition`。
+
+处理方式：
+
+- 使用 Chrome、Edge 或 Safari。
+- 或切换到 `faster_whisper`、`whisper_cpp`、`openai_whisper`。
+
+### 后端上传转写返回 503
+
+如果当前 Provider 是 `web_speech_api`，这是预期行为。它只支持浏览器端识别。
+
+处理方式：
+
+- 切换到 `faster_whisper`、`whisper_cpp` 或 `openai_whisper`。
+- 确认依赖和模型/API Key 可用。
+
+### 转写成功但没有自动发送
+
+默认行为是手动发送。语音转写会先填入聊天输入框，用户可以编辑后再发送。
+
+如果需要自动发送：
+
+1. 打开 `/settings/modules/hearing`。
+2. 启用 **Auto-send transcribed text**。
+3. 设置 `Auto-send delay`。
+
+---
+
+## 12. 修改建议
+
+优先通过 `/settings/modules/hearing` 修改 ASR 配置。只有在以下场景才建议直接编辑 YAML：
+
+- 初次配置环境变量占位符。
+- 批量调整本地模型路径。
+- 前端设置页无法启动，需要手工恢复默认 Provider。
+
+直接编辑 YAML 后，重启后端服务让配置生效。

--- a/docs/对话历史存储与批量删除说明.md
+++ b/docs/对话历史存储与批量删除说明.md
@@ -1,0 +1,171 @@
+# 对话历史存储与批量删除说明
+
+本文说明角色对话历史在后端的存储位置，以及如何批量删除历史记录。
+
+当前项目有两类容易混淆的“历史”：
+
+- 前端聊天列表历史：由 `/api/chats` 读写，决定侧边栏能看到哪些聊天标题和消息。
+- MemoryManager 角色记忆归档：由 `src/memory/chat_history.py` 读写，用于短期记忆恢复、压缩和长期记忆写入。
+
+## 前端聊天列表历史
+
+前端侧边栏的聊天标题、消息详情来自 `src/routes/chats.py` 和 `src/storage/json_storage.py`。
+
+默认配置在 `config/storage_config.yaml`：
+
+```yaml
+mode: json
+
+json:
+  base_path: data/chats
+```
+
+在通常从 `atri` 目录启动后端的情况下，实际路径是：
+
+```text
+atri/data/chats/default/{character_id}/index.json
+atri/data/chats/default/{character_id}/sessions/{chat_id}.json
+```
+
+说明：
+
+- `default` 是当前 Phase 5 写死的 `user_id`。
+- `{character_id}` 是角色 ID，例如 `atri` 或自定义角色 ID。
+- `index.json` 保存聊天列表元数据，包括 `id`、`title`、`created_at`、`updated_at`、`message_count`。
+- `sessions/{chat_id}.json` 保存该聊天的消息数组，格式为 `{"messages": [...]}`。
+- 前端删除某个聊天时调用 `POST /api/chats/{chat_id}/delete`，后端会同时移除 `index.json` 中的索引项和对应的 `sessions/{chat_id}.json`。
+
+如果后端从其他工作目录启动，相对路径 `data/chats` 会相对启动目录解析。无法确认时，先查看后端启动命令的工作目录。
+
+## MemoryManager 角色记忆归档
+
+聊天 Agent 还会把每轮对话写入 MemoryManager 的角色目录。默认配置在 `config/memory_config.yaml`：
+
+```yaml
+storage:
+  characters_dir: ./data/characters
+```
+
+通常路径是：
+
+```text
+atri/data/characters/{character_id}/short_term_memory.json
+atri/data/characters/{character_id}/sessions/{session_id}.json
+```
+
+说明：
+
+- `sessions/{session_id}.json` 是 `src/memory/chat_history.py` 写入的追加式归档。
+- `short_term_memory.json` 保存当前角色短期记忆状态，包括压缩块和最近轮次。
+- 删除前端聊天列表历史不会自动清理这些 MemoryManager 文件。
+- 如果启用了 mem0 长期记忆，本地模式还可能写入 `atri/data/qdrant`；SaaS 模式则写入外部 mem0 服务。当前仓库没有统一的长期记忆批量删除接口。
+
+## 删除前准备
+
+批量删除文件前建议先停止后端服务。后端运行时删除文件可能与正在写入的 `.tmp` 原子替换流程冲突。
+
+建议先备份：
+
+```powershell
+Compress-Archive -Path .\data\chats, .\data\characters -DestinationPath .\data-history-backup.zip -Force
+```
+
+以上命令应在 `atri` 目录执行。
+
+## 删除单个角色的前端聊天历史
+
+删除某个角色在前端侧边栏可见的全部聊天：
+
+```powershell
+Remove-Item -LiteralPath ".\data\chats\default\CHARACTER_ID" -Recurse -Force
+```
+
+将 `CHARACTER_ID` 替换为角色 ID。
+
+删除后重启后端，或刷新前端聊天列表。
+
+## 删除全部前端聊天历史
+
+删除当前默认用户的全部前端聊天历史：
+
+```powershell
+Remove-Item -LiteralPath ".\data\chats\default" -Recurse -Force
+```
+
+如果只想清空所有 JSON 聊天数据，也可以删除整个 `data/chats`：
+
+```powershell
+Remove-Item -LiteralPath ".\data\chats" -Recurse -Force
+```
+
+下次创建聊天时，后端会重新创建目录和索引文件。
+
+## 删除角色记忆归档
+
+仅删除某个角色的会话归档，保留短期记忆状态：
+
+```powershell
+Remove-Item -LiteralPath ".\data\characters\CHARACTER_ID\sessions" -Recurse -Force
+```
+
+同时重置该角色短期记忆：
+
+```powershell
+Remove-Item -LiteralPath ".\data\characters\CHARACTER_ID\short_term_memory.json" -Force
+```
+
+完全删除某个角色的 MemoryManager 本地记忆文件：
+
+```powershell
+Remove-Item -LiteralPath ".\data\characters\CHARACTER_ID" -Recurse -Force
+```
+
+注意：这不会删除角色 Persona 文件。角色卡文件在 `prompts/persona/{character_id}.md`，由角色管理功能维护。
+
+## 按标题批量删除前端聊天
+
+当前后端没有“按标题批量删除”的 REST API。可以在后端停止后，通过 PowerShell 修改 `index.json` 并删除匹配的 session 文件。
+
+下面示例删除指定角色下标题完全等于 `TITLE_TO_DELETE` 的聊天：
+
+```powershell
+$characterId = "CHARACTER_ID"
+$title = "TITLE_TO_DELETE"
+$chatDir = ".\data\chats\default\$characterId"
+$indexPath = Join-Path $chatDir "index.json"
+$sessionsDir = Join-Path $chatDir "sessions"
+
+$index = Get-Content -Raw -LiteralPath $indexPath | ConvertFrom-Json
+$matched = @($index.chats | Where-Object { $_.title -eq $title })
+
+foreach ($chat in $matched) {
+  $sessionPath = Join-Path $sessionsDir "$($chat.id).json"
+  Remove-Item -LiteralPath $sessionPath -Force -ErrorAction SilentlyContinue
+}
+
+$index.chats = @($index.chats | Where-Object { $_.title -ne $title })
+$index | ConvertTo-Json -Depth 10 | Set-Content -LiteralPath $indexPath -Encoding UTF8
+```
+
+按标题模糊匹配时，把匹配条件改成：
+
+```powershell
+Where-Object { $_.title -like "*关键词*" }
+```
+
+## 删除后检查
+
+检查某个角色剩余聊天数量：
+
+```powershell
+$index = Get-Content -Raw ".\data\chats\default\CHARACTER_ID\index.json" | ConvertFrom-Json
+$index.chats.Count
+```
+
+检查是否还有残留 session 文件：
+
+```powershell
+Get-ChildItem ".\data\chats\default\CHARACTER_ID\sessions" -Filter "*.json"
+```
+
+如果手动删除了 `index.json` 但保留了 `sessions` 文件，前端不会再显示这些孤立 session。后端按列表读取时以 `index.json` 为准。

--- a/docs/角色创建指南.md
+++ b/docs/角色创建指南.md
@@ -48,6 +48,7 @@ touch prompts/persona/my_character.md
 name: 角色显示名称
 avatar: avatar_filename.png
 greeting: 首次问候语
+description: 角色简介
 ---
 
 # 角色设定
@@ -130,7 +131,32 @@ avatar: atri.png
 
 ---
 
-#### 3. `greeting` - 首次问候语
+#### 3. `description` - 角色简介
+
+**类型**：`string | null`  
+**必填**：❌ 否（默认 `null`）  
+**用途**：角色的短简介，用于说明角色定位、气质和适合的聊天氛围
+
+**示例**：
+```yaml
+description: 高性能的情感型陪伴机器人，适合轻松、日常、带一点依赖感的聊天。
+```
+
+**前端字段映射**：
+- 前端创建角色卡时，表单里的 **简介** 字段对应 API payload 的 `description`
+- 后端会把 `description` 写入 persona Markdown 的 Frontmatter
+- 也就是说，**简介 = Frontmatter 的 `description` 字段**
+
+**前端使用场景**：
+- 角色卡片摘要
+- 角色详情弹窗的“简介”页签
+- 角色搜索：可通过简介内容筛选角色
+
+**长度限制**：当前 API 限制为 200 字以内
+
+---
+
+#### 4. `greeting` - 首次问候语
 
 **类型**：`string | null`  
 **必填**：❌ 否（默认 `null`）  
@@ -155,7 +181,7 @@ greeting: 主人，早上好！我是高性能的！
 
 ---
 
-#### 4. `system_prompt` - 系统提示词
+#### 5. `system_prompt` - 系统提示词
 
 **类型**：`string`  
 **必填**：✅ 是  
@@ -167,6 +193,7 @@ greeting: 主人，早上好！我是高性能的！
 ```markdown
 ---
 name: 亚托莉
+description: 高性能的情感型陪伴机器人。
 ---
 
 # 角色设定
@@ -219,32 +246,55 @@ const avatarUrl = `/avatars/${character.avatar || 'default.png'}`
 
 ---
 
-### 方案 B：后端静态文件服务（可选）
+### 方案 B：后端托管头像（当前实现）
 
 **目录结构**：
 ```
 atri/
-└── static/
+└── data/
     └── avatars/
-        ├── atri.png
-        └── my_character.png
+        ├── atri-d8e2f7da.jpg
+        └── my_character-xxxxxxxx.png
 ```
 
-**后端配置**（需要在 `src/app.py` 中添加）：
+**后端配置**（当前 `src/app.py` 已注册）：
 ```python
 from fastapi.staticfiles import StaticFiles
 
-app.mount("/static", StaticFiles(directory="static"), name="static")
+avatar_dir = get_default_character_avatar_dir()
+avatar_dir.mkdir(parents=True, exist_ok=True)
+
+app.mount(
+    "/api/assets/avatars",
+    StaticFiles(directory=str(avatar_dir), check_dir=False),
+    name="character-avatar-assets",
+)
+
+app.mount(
+    "/static/avatars",
+    StaticFiles(directory=str(avatar_dir), check_dir=False),
+    name="static-avatar-assets",
+)
 ```
 
 **前端访问**：
 ```typescript
-const avatarUrl = `http://localhost:8430/static/avatars/${character.avatar}`
+// 推荐：使用 API 返回的 avatar_url
+const avatarUrl = character.avatar_url
+
+// 兼容：只有 avatar 文件名时，也可以直接拼接
+const avatarUrlByFilename = `http://localhost:8430/static/avatars/${character.avatar}`
 ```
+
+**访问路径**：
+- 推荐路径：`http://localhost:8430/api/assets/avatars/${character.avatar}`
+- 兼容路径：`http://localhost:8430/static/avatars/${character.avatar}`
+- 物理目录：`atri/data/avatars/`
 
 **优点**：
 - ✅ 集中管理
 - ✅ 可以动态上传（Phase 7+）
+- ✅ 不依赖 `atri/static/` 目录
 
 ---
 
@@ -269,6 +319,7 @@ const avatarUrl = `http://localhost:8430/static/avatars/${character.avatar}`
 name: 亚托莉
 avatar: atri.png
 greeting: 主人，早上好！我是高性能的！
+description: 高性能的情感型陪伴机器人，适合轻松、日常、带一点依赖感的聊天。
 ---
 
 # 角色设定
@@ -350,13 +401,15 @@ GET http://localhost:8430/api/characters
     "character_id": "atri",
     "name": "亚托莉",
     "avatar": "atri.png",
-    "greeting": "主人，早上好！我是高性能的！"
+    "greeting": "主人，早上好！我是高性能的！",
+    "description": "高性能的情感型陪伴机器人，适合轻松、日常、带一点依赖感的聊天。"
   },
   {
     "character_id": "simple_bot",
     "name": "简单助手",
     "avatar": null,
-    "greeting": null
+    "greeting": null,
+    "description": null
   }
 ]
 ```
@@ -379,6 +432,7 @@ GET http://localhost:8430/api/characters/atri
   "name": "亚托莉",
   "avatar": "atri.png",
   "greeting": "主人，早上好！我是高性能的！",
+  "description": "高性能的情感型陪伴机器人，适合轻松、日常、带一点依赖感的聊天。",
   "system_prompt": "# 角色设定\n\n你是亚托莉（ATRI）..."
 }
 ```
@@ -398,6 +452,7 @@ GET http://localhost:8430/api/characters/atri
 │ name: 我的角色                                                │
 │ avatar: my_character.png                                     │
 │ greeting: 你好！                                              │
+│ description: 一个适合日常陪伴聊天的角色。                       │
 │ ---                                                          │
 │                                                              │
 │ 你是...                                                      │
@@ -412,6 +467,7 @@ GET http://localhost:8430/api/characters/atri
 │   name="我的角色",                                            │
 │   avatar="my_character.png",                                 │
 │   greeting="你好！",                                          │
+│   description="一个适合日常陪伴聊天的角色。",                    │
 │   system_prompt="你是..."                                    │
 │ )                                                            │
 └─────────────────────────────────────────────────────────────┘
@@ -425,7 +481,8 @@ GET http://localhost:8430/api/characters/atri
 │     "character_id": "my_character",                          │
 │     "name": "我的角色",                                       │
 │     "avatar": "my_character.png",                            │
-│     "greeting": "你好！"                                      │
+│     "greeting": "你好！",                                     │
+│     "description": "一个适合日常陪伴聊天的角色。"                │
 │   }                                                          │
 │ ]                                                            │
 └─────────────────────────────────────────────────────────────┘
@@ -435,6 +492,7 @@ GET http://localhost:8430/api/characters/atri
 │    atri-webui                                                │
 ├─────────────────────────────────────────────────────────────┤
 │ - 角色选择器：显示 name + avatar                              │
+│ - 角色卡片和详情弹窗：显示 description                         │
 │ - 聊天界面：显示 greeting                                    │
 │ - 消息气泡：显示 avatar                                       │
 └─────────────────────────────────────────────────────────────┘
@@ -644,6 +702,7 @@ class Persona:
     avatar: str | None
     greeting: str | None
     system_prompt: str
+    description: str | None = None
 ```
 
 ---
@@ -659,6 +718,7 @@ class Persona:
 name: 角色显示名称
 avatar: your_character.png
 greeting: 你好！我是 [角色名称]！
+description: 简要描述角色定位、气质和适合的聊天氛围。
 ---
 
 # 角色设定
@@ -690,10 +750,11 @@ greeting: 你好！我是 [角色名称]！
 
 | 日期 | 版本 | 说明 |
 |------|------|------|
+| 2026-04-25 | v1.1 | 补充前端“简介”字段与 Frontmatter `description` 的映射 |
 | 2026-04-21 | v1.0 | 初始版本，基于 Phase 5 实现 |
 
 ---
 
 **文档维护者**：Claude Code  
-**最后更新**：2026-04-21  
+**最后更新**：2026-04-25  
 **反馈渠道**：https://github.com/JuyaoHuang/atri/issues

--- a/prompts/persona/atri.md
+++ b/prompts/persona/atri.md
@@ -2,6 +2,7 @@
 name: 亚托莉
 avatar: atri.jpg
 greeting: 主人，早上好！我是高性能的！
+updated_at: '2026-04-25T04:55:23.329826Z'
 ---
 
 # 角色设定

--- a/src/agent/chat_agent.py
+++ b/src/agent/chat_agent.py
@@ -48,6 +48,7 @@ S1a / S1b / S5）：
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from typing import Any
 
 from loguru import logger
 
@@ -97,7 +98,11 @@ class ChatAgent:
         self.memory_manager = memory_manager
         self.persona = persona
 
-    async def chat(self, user_input: str) -> AsyncIterator[str]:
+    async def chat(
+        self,
+        user_input: str,
+        runtime_context: dict[str, Any] | None = None,
+    ) -> AsyncIterator[str]:
         """Stream LLM tokens for ``user_input`` and auto-commit the round.
 
         Sequence (success path, per §6.1):
@@ -157,10 +162,11 @@ class ChatAgent:
         产出：
             str：底层 LLM 流的每个 chunk（按到达顺序）。
         """
-        messages = await self.memory_manager.build_llm_context(
-            user_input,
-            system_prompt=self.persona.system_prompt,
-        )
+        context_kwargs: dict[str, Any] = {"system_prompt": self.persona.system_prompt}
+        if runtime_context:
+            context_kwargs["runtime_context"] = runtime_context
+
+        messages = await self.memory_manager.build_llm_context(user_input, **context_kwargs)
 
         reply_chunks: list[str] = []
         try:
@@ -210,7 +216,11 @@ class ChatAgent:
             {"role": "ai", "content": reply, "name": self.persona.name},
         )
 
-    async def chat_collect(self, user_input: str) -> str:
+    async def chat_collect(
+        self,
+        user_input: str,
+        runtime_context: dict[str, Any] | None = None,
+    ) -> str:
         """Collect :meth:`chat`'s streaming output into one string.
 
         Default implementation iterates :meth:`chat` so ``on_round_complete``
@@ -223,7 +233,7 @@ class ChatAgent:
         恰好触发一次。不走独立的 LLM 调用路径——当非流式 API 显著更廉价
         时，子类可以覆盖此方法。
         """
-        chunks = [chunk async for chunk in self.chat(user_input)]
+        chunks = [chunk async for chunk in self.chat(user_input, runtime_context=runtime_context)]
         return "".join(chunks)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -154,5 +154,12 @@ def create_app(config: dict) -> FastAPI:
     # 注册 WebSocket 端点
     app.websocket("/ws")(websocket_endpoint)
 
+    # Compatibility alias for direct avatar access by filename.
+    app.mount(
+        "/static/avatars",
+        StaticFiles(directory=str(avatar_dir), check_dir=False),
+        name="static-avatar-assets",
+    )
+    
     logger.info("FastAPI app created successfully")
     return app

--- a/src/app.py
+++ b/src/app.py
@@ -40,6 +40,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.staticfiles import StaticFiles
 from loguru import logger
 
+from src.asr import ASRConfigStore, ASRService
 from src.service_context import ServiceContext
 from src.storage.character_storage import CharacterStorage, get_default_character_avatar_dir
 from src.storage.factory import create_chat_storage
@@ -100,6 +101,7 @@ def create_app(config: dict) -> FastAPI:
     # Store config in app state for lifespan access
     # 将配置存储在 app state 中供 lifespan 访问
     app.state.config = config
+    app.state.asr_service = ASRService(ASRConfigStore(config.get("asr", {})))
     app.state.character_storage = CharacterStorage()
     app.state.live2d_storage = Live2DStorage()
 
@@ -135,6 +137,7 @@ def create_app(config: dict) -> FastAPI:
 
     # Register routes
     # 注册路由
+    from src.routes.asr import router as asr_router
     from src.routes.characters import router as characters_router
     from src.routes.chat_ws import websocket_endpoint
     from src.routes.chats import router as chats_router
@@ -142,6 +145,7 @@ def create_app(config: dict) -> FastAPI:
     from src.routes.live2d import router as live2d_router
 
     app.include_router(health_router)
+    app.include_router(asr_router)
     app.include_router(characters_router)
     app.include_router(chats_router)
     app.include_router(live2d_router)

--- a/src/asr/__init__.py
+++ b/src/asr/__init__.py
@@ -1,0 +1,17 @@
+"""Automatic speech recognition module."""
+
+from .config import DEFAULT_ASR_CONFIG, DEFAULT_ASR_CONFIG_PATH, ASRConfigStore
+from .factory import ASRFactory, ASRProviderMetadata
+from .interface import ASRHealth, ASRInterface
+from .service import ASRService
+
+__all__ = [
+    "ASRConfigStore",
+    "ASRFactory",
+    "ASRHealth",
+    "ASRInterface",
+    "ASRProviderMetadata",
+    "ASRService",
+    "DEFAULT_ASR_CONFIG",
+    "DEFAULT_ASR_CONFIG_PATH",
+]

--- a/src/asr/config.py
+++ b/src/asr/config.py
@@ -1,0 +1,152 @@
+"""ASR configuration loading and persistence."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_ATRI_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ASR_CONFIG_PATH = _ATRI_ROOT / "config" / "asr_config.yaml"
+SENSITIVE_CONFIG_KEYS = {"api_key", "token", "secret", "password"}
+
+DEFAULT_ASR_CONFIG: dict[str, Any] = {
+    "asr_model": "web_speech_api",
+    "auto_send": {
+        "enabled": False,
+        "delay_ms": 2000,
+    },
+    "web_speech_api": {
+        "language": "zh-CN",
+        "continuous": True,
+        "interim_results": True,
+        "max_alternatives": 1,
+    },
+    "faster_whisper": {
+        "model_path": "distil-medium.en",
+        "download_root": "models/whisper",
+        "language": "en",
+        "device": "auto",
+        "compute_type": "int8",
+        "prompt": "",
+    },
+    "whisper_cpp": {
+        "model_name": "small",
+        "model_dir": "models/whisper",
+        "print_realtime": False,
+        "print_progress": False,
+        "language": "auto",
+        "prompt": "",
+    },
+    "whisper": {
+        "name": "medium",
+        "download_root": "models/whisper",
+        "device": "cpu",
+        "prompt": "",
+    },
+    "openai_whisper": {
+        "model": "whisper-1",
+        "api_key": "${OPENAI_API_KEY}",
+        "base_url": "",
+        "language": "",
+        "prompt": "",
+    },
+}
+
+
+def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge mapping values without mutating inputs."""
+
+    result = deepcopy(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = deep_merge(result[key], value)
+        else:
+            result[key] = deepcopy(value)
+    return result
+
+
+class ASRConfigStore:
+    """Small YAML-backed configuration store for ASR settings."""
+
+    def __init__(
+        self,
+        initial_config: dict[str, Any] | None = None,
+        *,
+        path: Path | None = None,
+    ) -> None:
+        self.path = path or DEFAULT_ASR_CONFIG_PATH
+        raw_config = self._read_raw_config()
+        self._persist_config = deep_merge(
+            DEFAULT_ASR_CONFIG,
+            raw_config if raw_config is not None else initial_config or {},
+        )
+        self._config = deep_merge(
+            DEFAULT_ASR_CONFIG,
+            initial_config or raw_config or {},
+        )
+
+    def read(self) -> dict[str, Any]:
+        """Return a defensive copy of the current ASR config."""
+
+        return deepcopy(self._config)
+
+    def update(self, patch: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
+        """Merge a partial config update and persist it by default."""
+
+        self._config = deep_merge(self._config, patch)
+        self._persist_config = deep_merge(self._persist_config, patch)
+        if persist:
+            self.save()
+        return self.read()
+
+    def replace(self, config: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
+        """Replace the current config after applying defaults."""
+
+        self._config = deep_merge(DEFAULT_ASR_CONFIG, config)
+        self._persist_config = deep_merge(DEFAULT_ASR_CONFIG, config)
+        if persist:
+            self.save()
+        return self.read()
+
+    def save(self) -> None:
+        """Persist the current config to YAML."""
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.write_text(
+            yaml.safe_dump(
+                self._config_for_save(self._persist_config, DEFAULT_ASR_CONFIG),
+                allow_unicode=True,
+                sort_keys=False,
+            ),
+            encoding="utf-8",
+        )
+
+    def _read_raw_config(self) -> dict[str, Any] | None:
+        """Read the persisted ASR YAML without environment substitution."""
+
+        if not self.path.is_file():
+            return None
+        raw = yaml.safe_load(self.path.read_text(encoding="utf-8")) or {}
+        return raw if isinstance(raw, dict) else {}
+
+    def _config_for_save(
+        self,
+        config: dict[str, Any],
+        defaults: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return config safe to persist to disk."""
+
+        safe = deepcopy(config)
+        for key, value in safe.items():
+            default_value = defaults.get(key)
+            if isinstance(value, dict) and isinstance(default_value, dict):
+                safe[key] = self._config_for_save(value, default_value)
+            elif key.lower() in SENSITIVE_CONFIG_KEYS and self._is_env_placeholder(default_value):
+                safe[key] = default_value
+        return safe
+
+    def _is_env_placeholder(self, value: Any) -> bool:
+        return isinstance(value, str) and value.startswith("${") and value.endswith("}")

--- a/src/asr/exceptions.py
+++ b/src/asr/exceptions.py
@@ -1,0 +1,19 @@
+"""ASR-specific exception hierarchy."""
+
+from __future__ import annotations
+
+
+class ASRError(Exception):
+    """Base exception for ASR operations."""
+
+
+class ASRConfigError(ASRError):
+    """Raised when ASR configuration is invalid."""
+
+
+class ASRProviderUnavailableError(ASRError):
+    """Raised when a provider cannot run because dependencies or config are missing."""
+
+
+class ASRTranscriptionError(ASRError):
+    """Raised when transcription fails after a provider was selected."""

--- a/src/asr/factory.py
+++ b/src/asr/factory.py
@@ -1,0 +1,71 @@
+"""Decorator-based ASR provider registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from .interface import ASRInterface
+
+
+@dataclass(frozen=True)
+class ASRProviderMetadata:
+    """Static metadata shown in provider list responses."""
+
+    name: str
+    display_name: str
+    provider_type: str
+    supports_backend_transcription: bool
+    supports_browser_streaming: bool
+    description: str
+
+
+class ASRFactory:
+    """Class-scoped registry mapping provider name to provider class."""
+
+    _registry: dict[str, type[ASRInterface]] = {}
+    _metadata: dict[str, ASRProviderMetadata] = {}
+
+    @classmethod
+    def register(
+        cls,
+        name: str,
+        *,
+        metadata: ASRProviderMetadata,
+    ) -> Callable[[type[ASRInterface]], type[ASRInterface]]:
+        """Return a decorator that registers a provider class."""
+
+        def wrapper(provider_class: type[ASRInterface]) -> type[ASRInterface]:
+            provider_class.provider_name = name
+            provider_class.supports_backend_transcription = metadata.supports_backend_transcription
+            provider_class.supports_browser_streaming = metadata.supports_browser_streaming
+            cls._registry[name] = provider_class
+            cls._metadata[name] = metadata
+            return provider_class
+
+        return wrapper
+
+    @classmethod
+    def create(cls, name: str, **kwargs: Any) -> ASRInterface:
+        """Instantiate a registered provider by name."""
+
+        if name not in cls._registry:
+            available = sorted(cls._registry.keys())
+            raise ValueError(f"Unknown ASR provider: {name!r}. Available: {available}")
+        return cls._registry[name](**kwargs)
+
+    @classmethod
+    def available(cls) -> list[str]:
+        """Return sorted registered provider names."""
+
+        return sorted(cls._registry.keys())
+
+    @classmethod
+    def metadata(cls, name: str) -> ASRProviderMetadata:
+        """Return static metadata for a registered provider."""
+
+        if name not in cls._metadata:
+            available = sorted(cls._metadata.keys())
+            raise ValueError(f"Unknown ASR provider metadata: {name!r}. Available: {available}")
+        return cls._metadata[name]

--- a/src/asr/interface.py
+++ b/src/asr/interface.py
@@ -1,0 +1,173 @@
+"""ASR provider interface.
+
+The core contract mirrors Open-LLM-VTuber's ASR flow: local providers
+transcribe 16 kHz, mono, 16-bit PCM-style audio represented as a numeric
+array, and the async method delegates sync model work to a worker thread.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import wave
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any
+
+from .exceptions import ASRProviderUnavailableError, ASRTranscriptionError
+
+
+@dataclass(frozen=True)
+class ASRHealth:
+    """Provider availability state."""
+
+    available: bool
+    reason: str | None = None
+
+
+class ASRInterface(ABC):
+    """Base interface for all ASR providers."""
+
+    SAMPLE_RATE = 16000
+    NUM_CHANNELS = 1
+    SAMPLE_WIDTH = 2
+
+    provider_name = "unknown"
+    supports_backend_transcription = True
+    supports_browser_streaming = False
+
+    def __init__(self, **config: Any) -> None:
+        self.config = dict(config)
+
+    async def async_transcribe_np(self, audio: Any) -> str:
+        """Transcribe an OLV-style numeric audio array asynchronously."""
+
+        audio = self._ensure_float32_array(audio)
+        return await asyncio.to_thread(self.transcribe_np, audio)
+
+    @abstractmethod
+    def transcribe_np(self, audio: Any) -> str:
+        """Transcribe a 16 kHz mono float32 audio array."""
+
+    async def async_transcribe_audio(
+        self,
+        audio: bytes,
+        *,
+        filename: str | None = None,
+        content_type: str | None = None,
+    ) -> str:
+        """Transcribe uploaded audio bytes.
+
+        The default path converts 16 kHz mono PCM WAV bytes into the OLV
+        numeric-array contract and then calls :meth:`async_transcribe_np`.
+        Providers that can decode other formats should override this method.
+        """
+
+        if not audio:
+            raise ASRTranscriptionError("Uploaded audio is empty")
+        audio_array = self.audio_bytes_to_float32_array(
+            audio,
+            filename=filename,
+            content_type=content_type,
+        )
+        return await self.async_transcribe_np(audio_array)
+
+    def health(self) -> ASRHealth:
+        """Return provider availability without doing heavyweight model work."""
+
+        return ASRHealth(available=True)
+
+    def _ensure_float32_array(self, audio: Any) -> Any:
+        try:
+            import numpy as np
+        except ImportError as error:
+            raise ASRProviderUnavailableError(
+                "numpy is required for local ASR array transcription"
+            ) from error
+
+        if not isinstance(audio, np.ndarray):
+            audio = np.asarray(audio)
+        if audio.dtype != np.float32:
+            audio = audio.astype(np.float32)
+        return audio
+
+    def audio_bytes_to_float32_array(
+        self,
+        audio: bytes,
+        *,
+        filename: str | None = None,
+        content_type: str | None = None,
+    ) -> Any:
+        """Convert a PCM WAV upload into an OLV-style float32 mono array."""
+
+        try:
+            import numpy as np
+        except ImportError as error:
+            raise ASRProviderUnavailableError(
+                "numpy is required to decode WAV audio for local ASR providers"
+            ) from error
+
+        if not self._looks_like_wav(audio, filename=filename, content_type=content_type):
+            raise ASRTranscriptionError(
+                "Only PCM WAV uploads can be converted by the default ASR adapter"
+            )
+
+        try:
+            with wave.open(io.BytesIO(audio), "rb") as wav:
+                channels = wav.getnchannels()
+                sample_width = wav.getsampwidth()
+                sample_rate = wav.getframerate()
+                frames = wav.readframes(wav.getnframes())
+        except wave.Error as error:
+            raise ASRTranscriptionError("Uploaded audio is not a valid WAV file") from error
+
+        if sample_rate != self.SAMPLE_RATE:
+            raise ASRTranscriptionError(
+                f"Expected {self.SAMPLE_RATE} Hz WAV audio, got {sample_rate} Hz"
+            )
+        if sample_width not in {1, 2, 4}:
+            raise ASRTranscriptionError(f"Unsupported WAV sample width: {sample_width}")
+        if channels < 1:
+            raise ASRTranscriptionError("WAV audio must contain at least one channel")
+
+        if sample_width == 1:
+            samples = (np.frombuffer(frames, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+        elif sample_width == 2:
+            samples = np.frombuffer(frames, dtype=np.int16).astype(np.float32) / 32768.0
+        else:
+            samples = np.frombuffer(frames, dtype=np.int32).astype(np.float32) / 2147483648.0
+
+        if channels > 1:
+            samples = samples.reshape(-1, channels).mean(axis=1)
+
+        return np.clip(samples, -1.0, 1.0).astype(np.float32)
+
+    def nparray_to_audio_file(self, audio: Any, sample_rate: int, file_path: str) -> None:
+        """Write a numeric audio array as a mono 16-bit PCM WAV file."""
+
+        try:
+            import numpy as np
+        except ImportError as error:
+            raise ASRProviderUnavailableError("numpy is required to write ASR WAV audio") from error
+
+        audio = np.clip(self._ensure_float32_array(audio), -1, 1)
+        audio_integer = (audio * 32767).astype(np.int16)
+
+        with wave.open(file_path, "wb") as wav:
+            wav.setnchannels(self.NUM_CHANNELS)
+            wav.setsampwidth(self.SAMPLE_WIDTH)
+            wav.setframerate(sample_rate)
+            wav.writeframes(audio_integer.tobytes())
+
+    def _looks_like_wav(
+        self,
+        audio: bytes,
+        *,
+        filename: str | None = None,
+        content_type: str | None = None,
+    ) -> bool:
+        if audio.startswith(b"RIFF") and b"WAVE" in audio[:16]:
+            return True
+        if content_type in {"audio/wav", "audio/wave", "audio/x-wav"}:
+            return True
+        return bool(filename and filename.lower().endswith(".wav"))

--- a/src/asr/providers/__init__.py
+++ b/src/asr/providers/__init__.py
@@ -1,0 +1,10 @@
+"""ASR provider registrations."""
+
+from . import faster_whisper, openai_whisper, web_speech_api, whisper_cpp
+
+__all__ = [
+    "faster_whisper",
+    "openai_whisper",
+    "web_speech_api",
+    "whisper_cpp",
+]

--- a/src/asr/providers/faster_whisper.py
+++ b/src/asr/providers/faster_whisper.py
@@ -1,0 +1,125 @@
+"""faster-whisper ASR provider.
+
+The numpy-array transcription path follows Open-LLM-VTuber's
+`faster_whisper_asr.py`: lazy-create `WhisperModel`, call `transcribe`
+with beam search, optional language and prompt, and concatenate segment
+text.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from src.asr.exceptions import ASRProviderUnavailableError
+from src.asr.factory import ASRFactory, ASRProviderMetadata
+from src.asr.interface import ASRHealth, ASRInterface
+
+
+@ASRFactory.register(
+    "faster_whisper",
+    metadata=ASRProviderMetadata(
+        name="faster_whisper",
+        display_name="Faster Whisper",
+        provider_type="local",
+        supports_backend_transcription=True,
+        supports_browser_streaming=False,
+        description="Local faster-whisper transcription compatible with OLV flow.",
+    ),
+)
+class FasterWhisperASR(ASRInterface):
+    """Local faster-whisper provider with lazy optional dependency loading."""
+
+    BEAM_SEARCH = True
+
+    def __init__(self, **config: Any) -> None:
+        super().__init__(**config)
+        self.model_path = str(config.get("model_path") or "large-v3-turbo")
+        self.download_root = config.get("download_root") or None
+        self.language = config.get("language") or None
+        self.device = str(config.get("device") or "auto")
+        self.compute_type = str(config.get("compute_type") or "int8")
+        self.prompt = config.get("prompt") or None
+        self._model: Any | None = None
+
+    def health(self) -> ASRHealth:
+        if importlib.util.find_spec("faster_whisper") is None:
+            return ASRHealth(False, "Python package 'faster_whisper' is not installed")
+        if not self.model_path:
+            return ASRHealth(False, "faster_whisper.model_path is not configured")
+        return ASRHealth(True)
+
+    def transcribe_np(self, audio: Any) -> str:
+        model = self._get_model()
+        kwargs: dict[str, Any] = {
+            "beam_size": 5 if self.BEAM_SEARCH else 1,
+            "language": self.language if self.language and self.language != "auto" else None,
+            "condition_on_previous_text": False,
+        }
+        if self.prompt:
+            kwargs["initial_prompt"] = self.prompt
+
+        segments, _info = model.transcribe(audio, **kwargs)
+        return "".join(segment.text for segment in segments)
+
+    async def async_transcribe_audio(
+        self,
+        audio: bytes,
+        *,
+        filename: str | None = None,
+        content_type: str | None = None,
+    ) -> str:
+        """Transcribe uploaded audio.
+
+        WAV uploads use the OLV numpy-array path. Other browser formats are
+        passed to faster-whisper through a temporary file, which keeps the
+        provider usable with MediaRecorder while preserving `transcribe_np`
+        as the core local-provider contract.
+        """
+
+        if self._looks_like_wav(audio, filename=filename, content_type=content_type):
+            return await super().async_transcribe_audio(
+                audio, filename=filename, content_type=content_type
+            )
+
+        suffix = Path(filename or "recording.webm").suffix or ".webm"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as temp_audio:
+            temp_audio.write(audio)
+            temp_audio.flush()
+            return await self._async_transcribe_file_path(temp_audio.name)
+
+    async def _async_transcribe_file_path(self, path: str) -> str:
+        import asyncio
+
+        return await asyncio.to_thread(self._transcribe_file_path, path)
+
+    def _transcribe_file_path(self, path: str) -> str:
+        model = self._get_model()
+        kwargs: dict[str, Any] = {
+            "beam_size": 5 if self.BEAM_SEARCH else 1,
+            "language": self.language if self.language and self.language != "auto" else None,
+            "condition_on_previous_text": False,
+        }
+        if self.prompt:
+            kwargs["initial_prompt"] = self.prompt
+
+        segments, _info = model.transcribe(path, **kwargs)
+        return "".join(segment.text for segment in segments)
+
+    def _get_model(self) -> Any:
+        health = self.health()
+        if not health.available:
+            raise ASRProviderUnavailableError(health.reason or "faster_whisper is unavailable")
+
+        from faster_whisper import WhisperModel
+
+        if self._model is None:
+            self._model = WhisperModel(
+                model_size_or_path=self.model_path,
+                download_root=self.download_root,
+                device=self.device,
+                compute_type=self.compute_type,
+            )
+        return self._model

--- a/src/asr/providers/openai_whisper.py
+++ b/src/asr/providers/openai_whisper.py
@@ -1,0 +1,85 @@
+"""OpenAI Whisper-compatible cloud ASR provider."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from src.asr.exceptions import ASRProviderUnavailableError
+from src.asr.factory import ASRFactory, ASRProviderMetadata
+from src.asr.interface import ASRHealth, ASRInterface
+
+
+@ASRFactory.register(
+    "openai_whisper",
+    metadata=ASRProviderMetadata(
+        name="openai_whisper",
+        display_name="OpenAI Whisper",
+        provider_type="cloud",
+        supports_backend_transcription=True,
+        supports_browser_streaming=False,
+        description="Cloud audio transcription through the OpenAI-compatible SDK.",
+    ),
+)
+class OpenAIWhisperASR(ASRInterface):
+    """Cloud transcription provider with lazy OpenAI client creation."""
+
+    def __init__(self, **config: Any) -> None:
+        super().__init__(**config)
+        self.model = str(config.get("model") or "whisper-1")
+        self.api_key = str(config.get("api_key") or "")
+        self.base_url = str(config.get("base_url") or "")
+        self.language = str(config.get("language") or "")
+        self.prompt = str(config.get("prompt") or "")
+
+    def health(self) -> ASRHealth:
+        if importlib.util.find_spec("openai") is None:
+            return ASRHealth(False, "Python package 'openai' is not installed")
+        if not self.api_key or self.api_key.startswith("${"):
+            return ASRHealth(False, "openai_whisper.api_key is not configured")
+        if not self.model:
+            return ASRHealth(False, "openai_whisper.model is not configured")
+        return ASRHealth(True)
+
+    def transcribe_np(self, audio: Any) -> str:
+        raise ASRProviderUnavailableError(
+            "openai_whisper accepts uploaded audio files, not numpy arrays"
+        )
+
+    async def async_transcribe_audio(
+        self,
+        audio: bytes,
+        *,
+        filename: str | None = None,
+        content_type: str | None = None,
+    ) -> str:
+        health = self.health()
+        if not health.available:
+            raise ASRProviderUnavailableError(health.reason or "openai_whisper is unavailable")
+
+        suffix = Path(filename or "recording.wav").suffix or ".wav"
+        with tempfile.NamedTemporaryFile(suffix=suffix, delete=True) as temp_audio:
+            temp_audio.write(audio)
+            temp_audio.flush()
+            return await self._transcribe_file(temp_audio.name)
+
+    async def _transcribe_file(self, path: str) -> str:
+        from openai import AsyncOpenAI
+
+        client_kwargs: dict[str, Any] = {"api_key": self.api_key}
+        if self.base_url:
+            client_kwargs["base_url"] = self.base_url
+        client = AsyncOpenAI(**client_kwargs)
+
+        kwargs: dict[str, Any] = {"model": self.model}
+        if self.language:
+            kwargs["language"] = self.language
+        if self.prompt:
+            kwargs["prompt"] = self.prompt
+
+        with Path(path).open("rb") as audio_file:
+            response = await client.audio.transcriptions.create(file=audio_file, **kwargs)
+
+        return str(getattr(response, "text", "") or "")

--- a/src/asr/providers/web_speech_api.py
+++ b/src/asr/providers/web_speech_api.py
@@ -1,0 +1,55 @@
+"""Browser Web Speech API provider marker.
+
+The implementation follows AIRI's split: Web Speech API runs in the browser
+with live recognition, while the backend only exposes configuration and
+provider status.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.asr.exceptions import ASRProviderUnavailableError
+from src.asr.factory import ASRFactory, ASRProviderMetadata
+from src.asr.interface import ASRHealth, ASRInterface
+
+
+@ASRFactory.register(
+    "web_speech_api",
+    metadata=ASRProviderMetadata(
+        name="web_speech_api",
+        display_name="Web Speech API",
+        provider_type="browser",
+        supports_backend_transcription=False,
+        supports_browser_streaming=True,
+        description="Browser-native Web Speech API provider; transcription runs in frontend.",
+    ),
+)
+class WebSpeechAPIASR(ASRInterface):
+    """Configuration-only provider for browser Web Speech API."""
+
+    def __init__(self, **config: Any) -> None:
+        super().__init__(**config)
+        self.language = str(config.get("language") or "zh-CN")
+        self.continuous = bool(config.get("continuous", True))
+        self.interim_results = bool(config.get("interim_results", True))
+        self.max_alternatives = int(config.get("max_alternatives", 1))
+
+    def health(self) -> ASRHealth:
+        return ASRHealth(True, "Browser availability is checked in the frontend")
+
+    def transcribe_np(self, audio: Any) -> str:
+        raise ASRProviderUnavailableError(
+            "Web Speech API runs in the browser and does not support backend audio uploads"
+        )
+
+    async def async_transcribe_audio(
+        self,
+        audio: bytes,
+        *,
+        filename: str | None = None,
+        content_type: str | None = None,
+    ) -> str:
+        raise ASRProviderUnavailableError(
+            "Web Speech API runs in the browser and does not support backend audio uploads"
+        )

--- a/src/asr/providers/whisper_cpp.py
+++ b/src/asr/providers/whisper_cpp.py
@@ -1,0 +1,70 @@
+"""whisper.cpp ASR provider via pywhispercpp."""
+
+from __future__ import annotations
+
+import importlib.util
+from typing import Any
+
+from loguru import logger
+
+from src.asr.exceptions import ASRProviderUnavailableError
+from src.asr.factory import ASRFactory, ASRProviderMetadata
+from src.asr.interface import ASRHealth, ASRInterface
+
+
+@ASRFactory.register(
+    "whisper_cpp",
+    metadata=ASRProviderMetadata(
+        name="whisper_cpp",
+        display_name="Whisper.cpp",
+        provider_type="local",
+        supports_backend_transcription=True,
+        supports_browser_streaming=False,
+        description="Local pywhispercpp transcription compatible with OLV flow.",
+    ),
+)
+class WhisperCppASR(ASRInterface):
+    """Local whisper.cpp provider with lazy optional dependency loading."""
+
+    def __init__(self, **config: Any) -> None:
+        super().__init__(**config)
+        self.model_name = str(config.get("model_name") or "small")
+        self.model_dir = str(config.get("model_dir") or "models/whisper")
+        self.language = str(config.get("language") or "auto")
+        self.print_realtime = bool(config.get("print_realtime", False))
+        self.print_progress = bool(config.get("print_progress", False))
+        self.prompt = config.get("prompt") or None
+        self._model: Any | None = None
+
+    def health(self) -> ASRHealth:
+        if importlib.util.find_spec("pywhispercpp") is None:
+            return ASRHealth(False, "Python package 'pywhispercpp' is not installed")
+        if not self.model_name:
+            return ASRHealth(False, "whisper_cpp.model_name is not configured")
+        return ASRHealth(True)
+
+    def transcribe_np(self, audio: Any) -> str:
+        model = self._get_model()
+        kwargs: dict[str, Any] = {"new_segment_callback": logger.info}
+        if self.prompt:
+            kwargs["initial_prompt"] = self.prompt
+
+        segments = model.transcribe(audio, **kwargs)
+        return "".join(segment.text for segment in segments)
+
+    def _get_model(self) -> Any:
+        health = self.health()
+        if not health.available:
+            raise ASRProviderUnavailableError(health.reason or "whisper_cpp is unavailable")
+
+        from pywhispercpp.model import Model
+
+        if self._model is None:
+            self._model = Model(
+                model=self.model_name,
+                models_dir=self.model_dir,
+                language=self.language,
+                print_realtime=self.print_realtime,
+                print_progress=self.print_progress,
+            )
+        return self._model

--- a/src/asr/service.py
+++ b/src/asr/service.py
@@ -1,0 +1,169 @@
+"""ASR application service."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from . import providers as _providers  # noqa: F401
+from .config import ASRConfigStore
+from .exceptions import ASRConfigError, ASRProviderUnavailableError
+from .factory import ASRFactory
+
+SENSITIVE_CONFIG_KEYS = {"api_key", "token", "secret", "password"}
+SENSITIVE_CONFIG_MASK = "********"
+
+
+class ASRService:
+    """Coordinate ASR config, provider health, switching, and transcription."""
+
+    def __init__(self, config_store: ASRConfigStore) -> None:
+        self.config_store = config_store
+
+    def get_config(self) -> dict[str, Any]:
+        """Return persisted OLV-shaped ASR config."""
+
+        return self._public_config(self.config_store.read())
+
+    def update_config(self, patch: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
+        """Merge and persist a partial OLV-shaped ASR config update."""
+
+        patch = self._strip_masked_sensitive_values(patch)
+        next_model = patch.get("asr_model")
+        if next_model is not None:
+            self._ensure_provider_registered(str(next_model))
+        return self.config_store.update(patch, persist=persist)
+
+    def switch_provider(self, provider: str, *, persist: bool = True) -> dict[str, Any]:
+        """Switch the active ASR provider."""
+
+        self._ensure_provider_registered(provider)
+        return self.config_store.update({"asr_model": provider}, persist=persist)
+
+    def list_providers(self) -> list[dict[str, Any]]:
+        """Return registered provider metadata plus health/config state."""
+
+        config = self.config_store.read()
+        active_provider = self._active_provider(config)
+        providers: list[dict[str, Any]] = []
+
+        for name in ASRFactory.available():
+            metadata = ASRFactory.metadata(name)
+            provider_config = self._provider_config(config, name)
+            health = self._provider_health(name, provider_config)
+            providers.append(
+                {
+                    "name": metadata.name,
+                    "display_name": metadata.display_name,
+                    "provider_type": metadata.provider_type,
+                    "description": metadata.description,
+                    "active": name == active_provider,
+                    "available": health["available"],
+                    "reason": health["reason"],
+                    "supports_backend_transcription": metadata.supports_backend_transcription,
+                    "supports_browser_streaming": metadata.supports_browser_streaming,
+                    "config": self._public_config(provider_config),
+                }
+            )
+
+        return providers
+
+    def health(self) -> dict[str, Any]:
+        """Return active and all-provider ASR health state."""
+
+        config = self.config_store.read()
+        active_provider = self._active_provider(config)
+        providers = self.list_providers()
+        active = next(
+            (provider for provider in providers if provider["name"] == active_provider),
+            None,
+        )
+        return {
+            "active_provider": active_provider,
+            "active_available": bool(active and active["available"]),
+            "providers": providers,
+        }
+
+    async def transcribe_audio(
+        self,
+        audio: bytes,
+        *,
+        filename: str | None = None,
+        content_type: str | None = None,
+        provider: str | None = None,
+    ) -> dict[str, Any]:
+        """Transcribe uploaded audio with the selected backend-capable provider."""
+
+        config = self.config_store.read()
+        provider_name = provider or self._active_provider(config)
+        self._ensure_provider_registered(provider_name)
+        metadata = ASRFactory.metadata(provider_name)
+        if not metadata.supports_backend_transcription:
+            raise ASRProviderUnavailableError(
+                f"ASR provider '{provider_name}' does not support backend transcription"
+            )
+
+        provider_config = self._provider_config(config, provider_name)
+        asr = ASRFactory.create(provider_name, **provider_config)
+        health = asr.health()
+        if not health.available:
+            raise ASRProviderUnavailableError(health.reason or f"{provider_name} is unavailable")
+
+        text = await asr.async_transcribe_audio(
+            audio,
+            filename=filename,
+            content_type=content_type,
+        )
+        return {
+            "provider": provider_name,
+            "text": text,
+        }
+
+    def _provider_health(self, name: str, provider_config: dict[str, Any]) -> dict[str, Any]:
+        try:
+            health = ASRFactory.create(name, **provider_config).health()
+        except Exception as error:  # noqa: BLE001
+            return {"available": False, "reason": str(error)}
+        return {"available": health.available, "reason": health.reason}
+
+    def _active_provider(self, config: dict[str, Any]) -> str:
+        provider = str(config.get("asr_model") or "web_speech_api")
+        self._ensure_provider_registered(provider)
+        return provider
+
+    def _provider_config(self, config: dict[str, Any], provider: str) -> dict[str, Any]:
+        value = config.get(provider)
+        if isinstance(value, dict):
+            return dict(value)
+        return {}
+
+    def _ensure_provider_registered(self, provider: str) -> None:
+        if provider not in ASRFactory.available():
+            raise ASRConfigError(
+                f"Unknown ASR provider: {provider!r}. Available: {ASRFactory.available()}"
+            )
+
+    def _public_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Return config safe for API responses."""
+
+        safe: dict[str, Any] = {}
+        for key, value in config.items():
+            if key.lower() in SENSITIVE_CONFIG_KEYS:
+                safe[key] = SENSITIVE_CONFIG_MASK if value else value
+            elif isinstance(value, dict):
+                safe[key] = self._public_config(value)
+            else:
+                safe[key] = value
+        return safe
+
+    def _strip_masked_sensitive_values(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Remove masked secrets from incoming API patches."""
+
+        cleaned: dict[str, Any] = {}
+        for key, value in config.items():
+            if key.lower() in SENSITIVE_CONFIG_KEYS and value == SENSITIVE_CONFIG_MASK:
+                continue
+            if isinstance(value, dict):
+                cleaned[key] = self._strip_masked_sensitive_values(value)
+            else:
+                cleaned[key] = value
+        return cleaned

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -51,6 +51,7 @@ import json
 import secrets
 from collections.abc import Callable
 from datetime import UTC, datetime
+from html import escape
 from pathlib import Path
 from typing import Any
 
@@ -118,6 +119,49 @@ def _map_role(role: str) -> str:
     if mapped is None:
         raise ValueError(f"Unknown role: {role!r}")
     return mapped
+
+
+def _context_text(value: Any, max_length: int) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = " ".join(value.strip().split())
+    if not text:
+        return None
+    return text[:max_length]
+
+
+def _format_datetime_context(runtime_context: dict[str, Any] | None) -> str | None:
+    if not isinstance(runtime_context, dict):
+        return None
+
+    datetime_context = runtime_context.get("datetime")
+    if not isinstance(datetime_context, dict):
+        return None
+
+    iso = _context_text(datetime_context.get("iso"), 80)
+    local = _context_text(datetime_context.get("local"), 160)
+    time_zone = _context_text(datetime_context.get("time_zone"), 80)
+    utc_offset = _context_text(datetime_context.get("utc_offset"), 16)
+    if not iso and not local:
+        return None
+
+    content = f"Current datetime: {iso or 'unknown'}"
+    details = [detail for detail in (local, time_zone, utc_offset) if detail]
+    if details:
+        content = f"{content} ({'; '.join(details)})"
+    return content
+
+
+def _serialize_runtime_context(runtime_context: dict[str, Any] | None) -> str:
+    datetime_context = _format_datetime_context(runtime_context)
+    if not datetime_context:
+        return ""
+
+    return (
+        "<context>\n"
+        f'  <module name="system:datetime">{escape(datetime_context, quote=False)}</module>\n'
+        "</context>"
+    )
 
 
 class MemoryManager:
@@ -733,6 +777,7 @@ class MemoryManager:
         self,
         user_input: str,
         system_prompt: str = "",
+        runtime_context: dict[str, Any] | None = None,
     ) -> list[dict[str, Any]]:
         """Assemble the messages payload for the next LLM turn.
 
@@ -745,7 +790,8 @@ class MemoryManager:
           4. Each ``active_block['summary']``                 oldest-first
           5. ``recent_messages`` expanded one message each, with role
              mapping ``human`` -> ``user`` and ``ai`` -> ``assistant``.
-          6. ``user_input`` as a final ``{'role':'user', ...}``.
+          6. ``user_input`` as a final ``{'role':'user', ...}``, optionally
+             suffixed with hidden runtime context for the current LLM turn.
 
         This method does **not** call the LLM -- it only composes the list.
         ``ChatAgent`` (Phase 4) consumes the result and feeds it to
@@ -806,7 +852,12 @@ class MemoryManager:
                     }
                 )
 
-        messages.append({"role": "user", "content": user_input})
+        final_user_content = user_input
+        runtime_context_payload = _serialize_runtime_context(runtime_context)
+        if runtime_context_payload:
+            final_user_content = f"{user_input}\n\n{runtime_context_payload}"
+
+        messages.append({"role": "user", "content": final_user_content})
         return messages
 
 

--- a/src/models/asr.py
+++ b/src/models/asr.py
@@ -1,0 +1,50 @@
+"""ASR API schemas."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ASRProviderStatus(BaseModel):
+    """Provider metadata plus runtime availability."""
+
+    name: str
+    display_name: str
+    provider_type: str
+    description: str
+    active: bool
+    available: bool
+    reason: str | None = None
+    supports_backend_transcription: bool
+    supports_browser_streaming: bool
+    config: dict[str, Any] = Field(default_factory=dict)
+
+
+class ASRConfigResponse(BaseModel):
+    """OLV-shaped ASR config response."""
+
+    config: dict[str, Any]
+    providers: list[ASRProviderStatus] = Field(default_factory=list)
+
+
+class ASRHealthResponse(BaseModel):
+    """ASR health response."""
+
+    active_provider: str
+    active_available: bool
+    providers: list[ASRProviderStatus] = Field(default_factory=list)
+
+
+class ASRProviderSwitchRequest(BaseModel):
+    """Switch active provider payload."""
+
+    provider: str = Field(..., min_length=1)
+
+
+class ASRTranscriptionResponse(BaseModel):
+    """Transcription result response."""
+
+    provider: str
+    text: str

--- a/src/routes/asr.py
+++ b/src/routes/asr.py
@@ -1,0 +1,137 @@
+"""ASR management and transcription REST API routes."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile, status
+
+from src.asr import ASRConfigStore, ASRService
+from src.asr.exceptions import ASRConfigError, ASRProviderUnavailableError, ASRTranscriptionError
+from src.models.asr import (
+    ASRConfigResponse,
+    ASRHealthResponse,
+    ASRProviderStatus,
+    ASRProviderSwitchRequest,
+    ASRTranscriptionResponse,
+)
+
+router = APIRouter(prefix="/api/asr", tags=["asr"])
+
+
+def get_asr_service(request: Request) -> ASRService:
+    """Return app-scoped ASR service, creating a default one if needed."""
+
+    service = getattr(request.app.state, "asr_service", None)
+    if service is None:
+        service = ASRService(ASRConfigStore(request.app.state.config.get("asr", {})))
+        request.app.state.asr_service = service
+    return service
+
+
+ASRServiceDep = Annotated[ASRService, Depends(get_asr_service)]
+AudioFile = Annotated[UploadFile, File(...)]
+
+
+def _provider_status_list(raw: list[dict[str, Any]]) -> list[ASRProviderStatus]:
+    return [ASRProviderStatus(**provider) for provider in raw]
+
+
+def _handle_asr_error(error: Exception) -> HTTPException:
+    if isinstance(error, ASRConfigError):
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
+    if isinstance(error, ASRProviderUnavailableError):
+        return HTTPException(status_code=status.HTTP_503_SERVICE_UNAVAILABLE, detail=str(error))
+    if isinstance(error, ASRTranscriptionError):
+        return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
+    return HTTPException(
+        status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+        detail="ASR operation failed",
+    )
+
+
+@router.get("/providers", response_model=list[ASRProviderStatus])
+async def list_asr_providers(service: ASRServiceDep) -> list[ASRProviderStatus]:
+    """List registered ASR providers with health and config state."""
+
+    return _provider_status_list(service.list_providers())
+
+
+@router.get("/config", response_model=ASRConfigResponse)
+async def get_asr_config(service: ASRServiceDep) -> ASRConfigResponse:
+    """Return current OLV-shaped ASR config and provider statuses."""
+
+    return ASRConfigResponse(
+        config=service.get_config(),
+        providers=_provider_status_list(service.list_providers()),
+    )
+
+
+@router.put("/config", response_model=ASRConfigResponse)
+async def update_asr_config(
+    payload: dict[str, Any],
+    service: ASRServiceDep,
+) -> ASRConfigResponse:
+    """Merge and persist a partial OLV-shaped ASR config update."""
+
+    try:
+        service.update_config(payload)
+    except Exception as error:
+        raise _handle_asr_error(error) from error
+
+    return ASRConfigResponse(
+        config=service.get_config(),
+        providers=_provider_status_list(service.list_providers()),
+    )
+
+
+@router.post("/switch", response_model=ASRConfigResponse)
+async def switch_asr_provider(
+    payload: ASRProviderSwitchRequest,
+    service: ASRServiceDep,
+) -> ASRConfigResponse:
+    """Switch active ASR provider."""
+
+    try:
+        service.switch_provider(payload.provider)
+    except Exception as error:
+        raise _handle_asr_error(error) from error
+
+    return ASRConfigResponse(
+        config=service.get_config(),
+        providers=_provider_status_list(service.list_providers()),
+    )
+
+
+@router.get("/health", response_model=ASRHealthResponse)
+async def get_asr_health(service: ASRServiceDep) -> ASRHealthResponse:
+    """Return active provider and all-provider health."""
+
+    health = service.health()
+    return ASRHealthResponse(
+        active_provider=health["active_provider"],
+        active_available=health["active_available"],
+        providers=_provider_status_list(health["providers"]),
+    )
+
+
+@router.post("/transcribe", response_model=ASRTranscriptionResponse)
+async def transcribe_audio(
+    audio: AudioFile,
+    service: ASRServiceDep,
+    provider: str | None = None,
+) -> ASRTranscriptionResponse:
+    """Transcribe uploaded audio with the active or requested ASR provider."""
+
+    try:
+        payload = await audio.read()
+        result = await service.transcribe_audio(
+            payload,
+            filename=audio.filename,
+            content_type=audio.content_type,
+            provider=provider,
+        )
+    except Exception as error:
+        raise _handle_asr_error(error) from error
+
+    return ASRTranscriptionResponse(**result)

--- a/src/routes/chat_ws.py
+++ b/src/routes/chat_ws.py
@@ -133,6 +133,9 @@ async def _handle_text_input(
     text = data.get("text")
     chat_id = data.get("chat_id")
     character_id = data.get("character_id")
+    client_context = data.get("client_context")
+    if not isinstance(client_context, dict):
+        client_context = None
 
     # Validate required fields
     # 验证必填字段
@@ -166,7 +169,12 @@ async def _handle_text_input(
     # 流式传输 ChatAgent 响应
     chunks = []
     try:
-        async for chunk in agent.chat(text):
+        chat_stream = (
+            agent.chat(text, runtime_context=client_context)
+            if client_context
+            else agent.chat(text)
+        )
+        async for chunk in chat_stream:
             chunks.append(chunk)
             # Send chunk to client
             # 发送 chunk 给客户端

--- a/tests/agent/test_chat_agent.py
+++ b/tests/agent/test_chat_agent.py
@@ -133,6 +133,28 @@ async def test_build_llm_context_called_with_raw_user_input() -> None:
 
 
 @pytest.mark.asyncio
+async def test_runtime_context_passed_to_builder_but_not_committed() -> None:
+    mgr = _make_mgr()
+    agent = ChatAgent(_make_llm(["ok"]), mgr, _persona("SYS"))
+    runtime_context = {
+        "datetime": {
+            "iso": "2026-04-25T04:34:00.000Z",
+            "local": "2026/4/25 12:34:00",
+        }
+    }
+
+    [_ async for _ in agent.chat("what time is it?", runtime_context=runtime_context)]
+
+    mgr.build_llm_context.assert_awaited_once_with(
+        "what time is it?",
+        system_prompt="SYS",
+        runtime_context=runtime_context,
+    )
+    user_msg, _ai_msg = mgr.on_round_complete.await_args.args
+    assert user_msg == {"role": "human", "content": "what time is it?"}
+
+
+@pytest.mark.asyncio
 async def test_llm_stream_called_with_build_context_result() -> None:
     """chat_completion_stream is called with the messages list that
     build_llm_context returned.

--- a/tests/asr/test-exe.md
+++ b/tests/asr/test-exe.md
@@ -1,0 +1,55 @@
+# ASR Module - Test Execution
+
+## Offline Checks
+
+```powershell
+cd D:\Coding\GitHub_Resuorse\emotion-robot\atri
+uv run ruff check src tests/routes/test_asr.py
+uv run python -m mypy src/ --ignore-missing-imports
+uv run pytest tests/routes/test_asr.py -v
+```
+
+Expected:
+- Ruff: `All checks passed!`
+- Mypy: `Success: no issues found`
+- Pytest: `5 passed`
+
+## API Smoke Test
+
+Start the backend:
+
+```powershell
+cd D:\Coding\GitHub_Resuorse\emotion-robot\atri
+uv run uvicorn src.main:app --reload --host 127.0.0.1 --port 8430
+```
+
+Query ASR state:
+
+```powershell
+Invoke-RestMethod http://127.0.0.1:8430/api/asr/providers
+Invoke-RestMethod http://127.0.0.1:8430/api/asr/config
+Invoke-RestMethod http://127.0.0.1:8430/api/asr/health
+```
+
+Expected:
+- Providers include `web_speech_api`, `faster_whisper`, `whisper_cpp`, and `openai_whisper`.
+- `web_speech_api` is available for browser streaming and rejects backend transcription.
+- Missing optional local dependencies are reported as unavailable without failing startup.
+
+## Backend Transcription Smoke Test
+
+Prerequisites:
+- Select a backend transcription provider in `config/asr_config.yaml`.
+- Install the provider dependency and make the model/API key available.
+- Prepare a short WAV/WebM/OGG recording.
+
+```powershell
+Invoke-RestMethod `
+  -Method Post `
+  -Uri "http://127.0.0.1:8430/api/asr/transcribe?provider=faster_whisper" `
+  -Form @{ audio = Get-Item "D:\path\to\recording.wav" }
+```
+
+Expected:
+- Response contains `provider` and non-empty `text`.
+- If the provider cannot run, the API returns a clear 503 error.

--- a/tests/memory/test_manager.py
+++ b/tests/memory/test_manager.py
@@ -765,6 +765,47 @@ async def test_build_llm_context_empty_long_term_omits_position_2(
 
 
 @pytest.mark.asyncio
+async def test_build_llm_context_appends_runtime_datetime_context(tmp_path: Path) -> None:
+    mgr, _long_term = _make_manager_with_mock_long_term(tmp_path)
+    runtime_context = {
+        "datetime": {
+            "iso": "2026-04-25T04:34:00.000Z",
+            "local": "2026/4/25 12:34:00",
+            "time_zone": "Asia/Shanghai",
+            "utc_offset": "UTC+08:00",
+        }
+    }
+
+    messages = await mgr.build_llm_context("what time is it?", runtime_context=runtime_context)
+
+    final_content = messages[-1]["content"]
+    assert final_content.startswith("what time is it?\n\n<context>")
+    assert (
+        '<module name="system:datetime">Current datetime: '
+        "2026-04-25T04:34:00.000Z "
+        "(2026/4/25 12:34:00; Asia/Shanghai; UTC+08:00)</module>"
+    ) in final_content
+    assert final_content.endswith("</context>")
+
+
+@pytest.mark.asyncio
+async def test_build_llm_context_escapes_runtime_datetime_context(tmp_path: Path) -> None:
+    mgr, _long_term = _make_manager_with_mock_long_term(tmp_path)
+    runtime_context = {
+        "datetime": {
+            "iso": "2026-04-25T04:34:00.000Z",
+            "local": "<local & browser>",
+        }
+    }
+
+    messages = await mgr.build_llm_context("q", runtime_context=runtime_context)
+
+    final_content = messages[-1]["content"]
+    assert "<local & browser>" not in final_content
+    assert "&lt;local &amp; browser&gt;" in final_content
+
+
+@pytest.mark.asyncio
 async def test_build_llm_context_role_mapping(tmp_path: Path) -> None:
     """human -> user, ai -> assistant, system -> system.
 

--- a/tests/routes/test_asr.py
+++ b/tests/routes/test_asr.py
@@ -1,0 +1,256 @@
+"""Tests for Phase 9 ASR routes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+from src.app import create_app
+from src.asr import ASRConfigStore, ASRService
+from src.asr.providers import faster_whisper as faster_whisper_module
+from src.utils.config_loader import load_config
+
+
+@pytest_asyncio.fixture
+async def client_and_config_path(tmp_path: Path):
+    """Create test client with isolated ASR config persistence."""
+
+    config = load_config("config.yaml")
+    app = create_app(config)
+    config_path = tmp_path / "asr_config.yaml"
+    app.state.asr_service = ASRService(
+        ASRConfigStore(
+            {
+                "asr_model": "web_speech_api",
+                "auto_send": {"enabled": False, "delay_ms": 2000},
+            },
+            path=config_path,
+        )
+    )
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+        yield ac, config_path
+
+
+@pytest.mark.asyncio
+async def test_list_asr_providers_returns_registered_statuses(client_and_config_path):
+    client, _config_path = client_and_config_path
+
+    response = await client.get("/api/asr/providers")
+
+    assert response.status_code == 200
+    providers = response.json()
+    names = {provider["name"] for provider in providers}
+    assert {"web_speech_api", "faster_whisper", "whisper_cpp", "openai_whisper"} <= names
+
+    web_speech = next(provider for provider in providers if provider["name"] == "web_speech_api")
+    assert web_speech["active"] is True
+    assert web_speech["supports_backend_transcription"] is False
+    assert web_speech["supports_browser_streaming"] is True
+
+
+@pytest.mark.asyncio
+async def test_update_asr_config_persists_olv_shaped_config(client_and_config_path):
+    client, config_path = client_and_config_path
+
+    response = await client.put(
+        "/api/asr/config",
+        json={
+            "asr_model": "web_speech_api",
+            "auto_send": {"enabled": True, "delay_ms": 1200},
+            "web_speech_api": {"language": "en-US", "continuous": False},
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()["config"]
+    assert data["asr_model"] == "web_speech_api"
+    assert data["auto_send"] == {"enabled": True, "delay_ms": 1200}
+    assert data["web_speech_api"]["language"] == "en-US"
+    assert data["web_speech_api"]["continuous"] is False
+
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert persisted["asr_model"] == "web_speech_api"
+    assert persisted["auto_send"]["delay_ms"] == 1200
+
+
+def test_asr_config_store_preserves_raw_secret_placeholder_on_save(tmp_path: Path):
+    config_path = tmp_path / "asr_config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "asr_model: web_speech_api",
+                "openai_whisper:",
+                "  model: whisper-1",
+                "  api_key: ${OPENAI_API_KEY}",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    store = ASRConfigStore(
+        {
+            "asr_model": "web_speech_api",
+            "openai_whisper": {
+                "model": "whisper-1",
+                "api_key": "resolved-runtime-key",
+            },
+        },
+        path=config_path,
+    )
+
+    assert store.read()["openai_whisper"]["api_key"] == "resolved-runtime-key"
+
+    store.update({"auto_send": {"enabled": True, "delay_ms": 1500}})
+
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert persisted["openai_whisper"]["api_key"] == "${OPENAI_API_KEY}"
+    assert persisted["auto_send"] == {"enabled": True, "delay_ms": 1500}
+
+
+def test_asr_config_store_scrubs_runtime_secret_on_save(tmp_path: Path):
+    config_path = tmp_path / "asr_config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "asr_model: web_speech_api",
+                "openai_whisper:",
+                "  model: whisper-1",
+                "  api_key: resolved-runtime-key",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    store = ASRConfigStore(path=config_path)
+
+    store.update({"auto_send": {"enabled": False, "delay_ms": 1000}})
+
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert persisted["openai_whisper"]["api_key"] == "${OPENAI_API_KEY}"
+
+
+def test_asr_service_masks_secret_values_in_public_config(tmp_path: Path):
+    service = ASRService(
+        ASRConfigStore(
+            {
+                "asr_model": "openai_whisper",
+                "openai_whisper": {
+                    "model": "whisper-1",
+                    "api_key": "resolved-runtime-key",
+                },
+            },
+            path=tmp_path / "asr_config.yaml",
+        )
+    )
+
+    config = service.get_config()
+    providers = service.list_providers()
+
+    assert config["openai_whisper"]["api_key"] == "********"
+    openai_provider = next(
+        provider for provider in providers if provider["name"] == "openai_whisper"
+    )
+    assert openai_provider["config"]["api_key"] == "********"
+
+
+def test_asr_service_ignores_masked_secret_patch(tmp_path: Path):
+    config_path = tmp_path / "asr_config.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "asr_model: openai_whisper",
+                "openai_whisper:",
+                "  model: whisper-1",
+                "  api_key: ${OPENAI_API_KEY}",
+                "  base_url: ''",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    service = ASRService(
+        ASRConfigStore(
+            {
+                "asr_model": "openai_whisper",
+                "openai_whisper": {
+                    "model": "whisper-1",
+                    "api_key": "resolved-runtime-key",
+                    "base_url": "",
+                },
+            },
+            path=config_path,
+        )
+    )
+
+    service.update_config(
+        {
+            "openai_whisper": {
+                "model": "gpt-4o-mini-transcribe",
+                "api_key": "********",
+            }
+        }
+    )
+
+    raw_config = service.config_store.read()
+    persisted = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert raw_config["openai_whisper"]["api_key"] == "resolved-runtime-key"
+    assert raw_config["openai_whisper"]["model"] == "gpt-4o-mini-transcribe"
+    assert persisted["openai_whisper"]["api_key"] == "${OPENAI_API_KEY}"
+    assert persisted["openai_whisper"]["model"] == "gpt-4o-mini-transcribe"
+
+
+@pytest.mark.asyncio
+async def test_switch_asr_provider_rejects_unknown_provider(client_and_config_path):
+    client, _config_path = client_and_config_path
+
+    response = await client.post("/api/asr/switch", json={"provider": "unknown"})
+
+    assert response.status_code == 400
+    assert "Unknown ASR provider" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_web_speech_api_rejects_backend_transcription(client_and_config_path):
+    client, _config_path = client_and_config_path
+
+    response = await client.post(
+        "/api/asr/transcribe",
+        files={"audio": ("recording.wav", b"not-used", "audio/wav")},
+    )
+
+    assert response.status_code == 503
+    assert "does not support backend transcription" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_missing_optional_faster_whisper_dependency_returns_503(
+    client_and_config_path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    client, _config_path = client_and_config_path
+    original_find_spec = faster_whisper_module.importlib.util.find_spec
+
+    def fake_find_spec(name: str, *args, **kwargs):
+        if name == "faster_whisper":
+            return None
+        return original_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(faster_whisper_module.importlib.util, "find_spec", fake_find_spec)
+
+    switch_response = await client.post("/api/asr/switch", json={"provider": "faster_whisper"})
+    assert switch_response.status_code == 200
+
+    response = await client.post(
+        "/api/asr/transcribe",
+        files={"audio": ("recording.wav", b"not-used", "audio/wav")},
+    )
+
+    assert response.status_code == 503
+    assert "faster_whisper" in response.json()["detail"]

--- a/tests/routes/test_chat_ws.py
+++ b/tests/routes/test_chat_ws.py
@@ -171,6 +171,63 @@ async def test_websocket_text_input_streaming(
 
 
 @pytest.mark.asyncio
+async def test_websocket_text_input_passes_client_context_without_persisting_it(
+    mock_config: dict, mock_service_context: tuple, mock_storage: AsyncMock
+) -> None:
+    mock_context, mock_agent = mock_service_context
+    chunks = ["It is noon."]
+    client_context = {
+        "datetime": {
+            "iso": "2026-04-25T04:00:00.000Z",
+            "local": "2026/4/25 12:00:00",
+            "time_zone": "Asia/Shanghai",
+            "utc_offset": "UTC+08:00",
+        }
+    }
+    mock_agent.chat = MagicMock(
+        side_effect=lambda text, runtime_context=None: _mock_chat_stream(chunks)
+    )
+
+    with (
+        patch("src.app.ServiceContext", return_value=mock_context),
+        patch("src.app.create_chat_storage", return_value=mock_storage),
+    ):
+        app = create_app(mock_config)
+        app.state.service_context = mock_context
+        app.state.storage = mock_storage
+
+        client = TestClient(app)
+
+        with client.websocket_connect("/ws") as websocket:
+            websocket.send_json(
+                {
+                    "type": "input:text",
+                    "data": {
+                        "text": "what time is it?",
+                        "chat_id": "test_chat_time",
+                        "character_id": "atri",
+                        "client_context": client_context,
+                    },
+                }
+            )
+
+            chunk_response = websocket.receive_json()
+            assert chunk_response["type"] == "output:chat:chunk"
+            complete_response = websocket.receive_json()
+            assert complete_response["type"] == "output:chat:complete"
+
+            mock_agent.chat.assert_called_once_with(
+                "what time is it?",
+                runtime_context=client_context,
+            )
+            mock_storage.append_message.assert_any_call(
+                "test_chat_time", "human", "what time is it?", name="default"
+            )
+            persisted_user_args = mock_storage.append_message.call_args_list[0].args
+            assert persisted_user_args == ("test_chat_time", "human", "what time is it?")
+
+
+@pytest.mark.asyncio
 async def test_websocket_invalid_json(
     mock_config: dict, mock_service_context: tuple, mock_storage: AsyncMock
 ) -> None:


### PR DESCRIPTION
## Summary
- add ASR module with provider registry and four providers
- add ASR config service and /api/asr endpoints
- add runtime datetime context support for chat

## Checks
- uv run pytest tests/routes/test_asr.py -q
- uv run ruff check src/asr src/routes/asr.py tests/routes/test_asr.py
- uv run python -m mypy src/ --ignore-missing-imports

## Notes
- Functional ASR device/model verification was intentionally skipped per user request; follow-up debugging will happen if runtime ASR fails.