### PR TITLE
feat(auth): issue http-only session cookies

### DIFF
--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException, Request, WebSocket, status
 
 from src.auth.exceptions import AuthError
 from src.auth.service import AuthService
+from src.auth.session import SESSION_COOKIE_NAME
 
 DEFAULT_USER_ID = "default"
 
@@ -29,7 +30,10 @@ def get_request_user_id(request: Request) -> str:
     if not auth_service.enabled:
         return DEFAULT_USER_ID
     try:
-        user = auth_service.authenticate_bearer_token(request.headers.get("Authorization"))
+        user = auth_service.authenticate_credentials(
+            authorization=request.headers.get("Authorization"),
+            session_token=request.cookies.get(SESSION_COOKIE_NAME),
+        )
     except AuthError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -44,13 +48,14 @@ def get_websocket_user_id(websocket: WebSocket) -> str:
     auth_service = get_auth_service(websocket.app)
     if not auth_service.enabled:
         return DEFAULT_USER_ID
-    token = websocket.query_params.get("token")
     try:
-        user = auth_service.authenticate_token(token)
+        user = auth_service.authenticate_credentials(
+            authorization=None,
+            session_token=websocket.cookies.get(SESSION_COOKIE_NAME),
+        )
     except AuthError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail=str(exc),
         ) from exc
     return user.username
-

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -8,6 +8,7 @@ from typing import Any
 from src.auth.exceptions import AuthConfigError, AuthTokenError, AuthUnauthorizedError
 from src.auth.jwt import JWTManager
 from src.auth.oauth import GitHubOAuth, GitHubUser
+from src.auth.session import SESSION_COOKIE_NAME
 from src.auth.whitelist import Whitelist
 
 
@@ -32,6 +33,8 @@ class AuthService:
 
         self.jwt_manager: JWTManager | None = None
         self.github_oauth: GitHubOAuth | None = None
+        self.session_cookie_name = SESSION_COOKIE_NAME
+        self.session_cookie_max_age_seconds = int(jwt_config.get("expire_days", 7)) * 24 * 60 * 60
         self.whitelist = Whitelist(whitelist_config.get("users", []))
         self.frontend_callback_url = str(
             config.get("frontend", {}).get("callback_url")
@@ -70,6 +73,20 @@ class AuthService:
             raise AuthTokenError("Missing bearer token")
         return self.authenticate_token(authorization.removeprefix("Bearer ").strip())
 
+    def authenticate_credentials(
+        self,
+        *,
+        authorization: str | None,
+        session_token: str | None,
+    ) -> AuthenticatedUser:
+        if not self.enabled:
+            return AuthenticatedUser(username="default")
+        if session_token:
+            return self.authenticate_token(session_token)
+        if authorization and authorization.startswith("Bearer "):
+            return self.authenticate_bearer_token(authorization)
+        raise AuthTokenError("Missing session cookie")
+
     def authenticate_token(self, token: str | None) -> AuthenticatedUser:
         if not self.enabled:
             return AuthenticatedUser(username="default")
@@ -86,4 +103,3 @@ class AuthService:
             username=username,
             avatar_url=avatar_url if isinstance(avatar_url, str) else None,
         )
-

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,0 +1,5 @@
+"""Shared session-cookie constants for authentication."""
+
+SESSION_COOKIE_NAME = "atri_session"
+SESSION_COOKIE_PATH = "/"
+SESSION_COOKIE_SAMESITE = "lax"

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -7,6 +7,7 @@ from starlette.responses import JSONResponse, Response
 
 from src.auth.dependencies import get_auth_service
 from src.auth.exceptions import AuthError
+from src.auth.session import SESSION_COOKIE_NAME
 
 PUBLIC_PATH_PREFIXES = (
     "/api/auth",
@@ -29,10 +30,12 @@ async def auth_middleware(request: Request, call_next) -> Response:
         return await call_next(request)
 
     try:
-        user = auth_service.authenticate_bearer_token(request.headers.get("Authorization"))
+        user = auth_service.authenticate_credentials(
+            authorization=request.headers.get("Authorization"),
+            session_token=request.cookies.get(SESSION_COOKIE_NAME),
+        )
     except AuthError as exc:
         return JSONResponse({"detail": str(exc)}, status_code=401)
 
     request.state.user_id = user.username
     return await call_next(request)
-

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import secrets
 from urllib.parse import urlencode
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi import APIRouter, HTTPException, Query, Request, Response, status
 from pydantic import BaseModel
 from starlette.responses import RedirectResponse
 
@@ -12,6 +13,10 @@ from src.auth.dependencies import DEFAULT_USER_ID, get_auth_service
 from src.auth.exceptions import AuthError
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+OAUTH_STATE_COOKIE_NAME = "atri_oauth_state"
+OAUTH_STATE_COOKIE_MAX_AGE_SECONDS = 10 * 60
+OAUTH_STATE_COOKIE_PATH = "/api/auth"
 
 
 class AuthStatusResponse(BaseModel):
@@ -39,6 +44,51 @@ def _redirect_with_params(base_url: str, params: dict[str, str]) -> RedirectResp
     return RedirectResponse(f"{base_url}{separator}{urlencode(params)}")
 
 
+def _is_secure_oauth_cookie(request: Request) -> bool:
+    auth_service = get_auth_service(request.app)
+    callback_url = auth_service.github_oauth.callback_url if auth_service.github_oauth else ""
+    return callback_url.startswith("https://")
+
+
+def _set_oauth_state_cookie(request: Request, response: Response, state: str) -> None:
+    response.set_cookie(
+        key=OAUTH_STATE_COOKIE_NAME,
+        value=state,
+        max_age=OAUTH_STATE_COOKIE_MAX_AGE_SECONDS,
+        path=OAUTH_STATE_COOKIE_PATH,
+        secure=_is_secure_oauth_cookie(request),
+        httponly=True,
+        samesite="lax",
+    )
+
+
+def _clear_oauth_state_cookie(request: Request, response: Response) -> None:
+    response.delete_cookie(
+        key=OAUTH_STATE_COOKIE_NAME,
+        path=OAUTH_STATE_COOKIE_PATH,
+        secure=_is_secure_oauth_cookie(request),
+        httponly=True,
+        samesite="lax",
+    )
+
+
+def _redirect_with_cleared_oauth_state(
+    request: Request,
+    base_url: str,
+    params: dict[str, str],
+) -> RedirectResponse:
+    response = _redirect_with_params(base_url, params)
+    _clear_oauth_state_cookie(request, response)
+    return response
+
+
+def _is_valid_oauth_state(request: Request, state: str | None) -> bool:
+    expected_state = request.cookies.get(OAUTH_STATE_COOKIE_NAME)
+    if not state or not expected_state:
+        return False
+    return secrets.compare_digest(state, expected_state)
+
+
 @router.get("/status", response_model=AuthStatusResponse)
 async def get_auth_status(request: Request) -> AuthStatusResponse:
     auth_service = get_auth_service(request.app)
@@ -48,16 +98,20 @@ async def get_auth_status(request: Request) -> AuthStatusResponse:
 @router.get("/login", response_model=AuthLoginResponse)
 async def get_login_url(
     request: Request,
-    state: str | None = Query(None),
+    response: Response,
+    state: str | None = Query(None),  # Kept for backward-compatible clients; ignored.
 ) -> AuthLoginResponse:
     auth_service = get_auth_service(request.app)
     if not auth_service.enabled:
         return AuthLoginResponse(enabled=False, authorization_url=None)
     if auth_service.github_oauth is None:
         raise HTTPException(status_code=500, detail="GitHub OAuth is not configured")
+
+    oauth_state = secrets.token_urlsafe(32)
+    _set_oauth_state_cookie(request, response, oauth_state)
     return AuthLoginResponse(
         enabled=True,
-        authorization_url=auth_service.github_oauth.get_authorization_url(state=state),
+        authorization_url=auth_service.github_oauth.get_authorization_url(state=oauth_state),
     )
 
 
@@ -65,17 +119,40 @@ async def get_login_url(
 async def github_callback(
     request: Request,
     code: str | None = Query(None),
+    state: str | None = Query(None),
     error: str | None = Query(None),
 ) -> RedirectResponse:
     auth_service = get_auth_service(request.app)
     if not auth_service.enabled:
-        return _redirect_with_params(auth_service.frontend_callback_url, {"auth": "disabled"})
+        return _redirect_with_cleared_oauth_state(
+            request,
+            auth_service.frontend_callback_url,
+            {"auth": "disabled"},
+        )
     if error:
-        return _redirect_with_params(auth_service.frontend_callback_url, {"error": error})
+        return _redirect_with_cleared_oauth_state(
+            request,
+            auth_service.frontend_callback_url,
+            {"error": error},
+        )
     if not code:
-        return _redirect_with_params(auth_service.frontend_callback_url, {"error": "missing_code"})
+        return _redirect_with_cleared_oauth_state(
+            request,
+            auth_service.frontend_callback_url,
+            {"error": "missing_code"},
+        )
     if auth_service.github_oauth is None:
-        return _redirect_with_params(auth_service.frontend_callback_url, {"error": "oauth_config"})
+        return _redirect_with_cleared_oauth_state(
+            request,
+            auth_service.frontend_callback_url,
+            {"error": "oauth_config"},
+        )
+    if not _is_valid_oauth_state(request, state):
+        return _redirect_with_cleared_oauth_state(
+            request,
+            auth_service.frontend_callback_url,
+            {"error": "invalid_state"},
+        )
 
     try:
         access_token = await auth_service.github_oauth.exchange_code_for_token(code)
@@ -83,12 +160,14 @@ async def github_callback(
         auth_service.require_allowed_user(github_user)
         token = auth_service.create_token_for_github_user(github_user)
     except AuthError as exc:
-        return _redirect_with_params(
+        return _redirect_with_cleared_oauth_state(
+            request,
             auth_service.frontend_callback_url,
             {"error": "unauthorized", "detail": str(exc)},
         )
     except Exception:
-        return _redirect_with_params(
+        return _redirect_with_cleared_oauth_state(
+            request,
             auth_service.frontend_callback_url,
             {"error": "github_oauth_failed"},
         )
@@ -99,7 +178,7 @@ async def github_callback(
     }
     if github_user.avatar_url:
         params["avatar_url"] = github_user.avatar_url
-    return _redirect_with_params(auth_service.frontend_callback_url, params)
+    return _redirect_with_cleared_oauth_state(request, auth_service.frontend_callback_url, params)
 
 
 @router.get("/me", response_model=AuthUserResponse)
@@ -125,4 +204,3 @@ async def get_current_user(request: Request) -> AuthUserResponse:
 @router.post("/logout", response_model=AuthLogoutResponse)
 async def logout() -> AuthLogoutResponse:
     return AuthLogoutResponse(success=True)
-

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -11,6 +11,7 @@ from starlette.responses import RedirectResponse
 
 from src.auth.dependencies import DEFAULT_USER_ID, get_auth_service
 from src.auth.exceptions import AuthError
+from src.auth.session import SESSION_COOKIE_NAME, SESSION_COOKIE_PATH, SESSION_COOKIE_SAMESITE
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
@@ -50,6 +51,11 @@ def _is_secure_oauth_cookie(request: Request) -> bool:
     return callback_url.startswith("https://")
 
 
+def _is_secure_session_cookie(request: Request) -> bool:
+    auth_service = get_auth_service(request.app)
+    return auth_service.frontend_callback_url.startswith("https://")
+
+
 def _set_oauth_state_cookie(request: Request, response: Response, state: str) -> None:
     response.set_cookie(
         key=OAUTH_STATE_COOKIE_NAME,
@@ -59,6 +65,29 @@ def _set_oauth_state_cookie(request: Request, response: Response, state: str) ->
         secure=_is_secure_oauth_cookie(request),
         httponly=True,
         samesite="lax",
+    )
+
+
+def _set_session_cookie(request: Request, response: Response, token: str) -> None:
+    auth_service = get_auth_service(request.app)
+    response.set_cookie(
+        key=SESSION_COOKIE_NAME,
+        value=token,
+        max_age=auth_service.session_cookie_max_age_seconds,
+        path=SESSION_COOKIE_PATH,
+        secure=_is_secure_session_cookie(request),
+        httponly=True,
+        samesite=SESSION_COOKIE_SAMESITE,
+    )
+
+
+def _clear_session_cookie(request: Request, response: Response) -> None:
+    response.delete_cookie(
+        key=SESSION_COOKIE_NAME,
+        path=SESSION_COOKIE_PATH,
+        secure=_is_secure_session_cookie(request),
+        httponly=True,
+        samesite=SESSION_COOKIE_SAMESITE,
     )
 
 
@@ -172,13 +201,13 @@ async def github_callback(
             {"error": "github_oauth_failed"},
         )
 
-    params = {
-        "token": token,
-        "username": github_user.username,
-    }
-    if github_user.avatar_url:
-        params["avatar_url"] = github_user.avatar_url
-    return _redirect_with_cleared_oauth_state(request, auth_service.frontend_callback_url, params)
+    response = _redirect_with_cleared_oauth_state(
+        request,
+        auth_service.frontend_callback_url,
+        {"success": "1"},
+    )
+    _set_session_cookie(request, response, token)
+    return response
 
 
 @router.get("/me", response_model=AuthUserResponse)
@@ -187,7 +216,10 @@ async def get_current_user(request: Request) -> AuthUserResponse:
     if not auth_service.enabled:
         return AuthUserResponse(username=DEFAULT_USER_ID, auth_enabled=False)
     try:
-        user = auth_service.authenticate_bearer_token(request.headers.get("Authorization"))
+        user = auth_service.authenticate_credentials(
+            authorization=request.headers.get("Authorization"),
+            session_token=request.cookies.get(SESSION_COOKIE_NAME),
+        )
     except AuthError as exc:
         raise HTTPException(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -202,5 +234,6 @@ async def get_current_user(request: Request) -> AuthUserResponse:
 
 
 @router.post("/logout", response_model=AuthLogoutResponse)
-async def logout() -> AuthLogoutResponse:
+async def logout(request: Request, response: Response) -> AuthLogoutResponse:
+    _clear_session_cookie(request, response)
     return AuthLogoutResponse(success=True)

--- a/tests/auth/test_service.py
+++ b/tests/auth/test_service.py
@@ -63,6 +63,69 @@ def test_enabled_auth_requires_bearer_token() -> None:
         service.authenticate_bearer_token(None)
 
 
+def test_enabled_auth_accepts_session_credentials() -> None:
+    service = AuthService(
+        {
+            "enabled": True,
+            "jwt": {"secret_key": "test-secret", "algorithm": "HS256", "expire_days": 7},
+            "github": {
+                "client_id": "client",
+                "client_secret": "secret",
+                "callback_url": "http://localhost:8430/api/auth/callback",
+            },
+            "whitelist": {"users": ["JuyaoHuang"]},
+        }
+    )
+    assert service.jwt_manager is not None
+    token = service.jwt_manager.create_token("JuyaoHuang")
+
+    user = service.authenticate_credentials(authorization=None, session_token=token)
+
+    assert user.username == "JuyaoHuang"
+
+
+def test_enabled_auth_credentials_keep_bearer_compatibility() -> None:
+    service = AuthService(
+        {
+            "enabled": True,
+            "jwt": {"secret_key": "test-secret", "algorithm": "HS256", "expire_days": 7},
+            "github": {
+                "client_id": "client",
+                "client_secret": "secret",
+                "callback_url": "http://localhost:8430/api/auth/callback",
+            },
+            "whitelist": {"users": ["JuyaoHuang"]},
+        }
+    )
+    assert service.jwt_manager is not None
+    token = service.jwt_manager.create_token("JuyaoHuang")
+
+    user = service.authenticate_credentials(
+        authorization=f"Bearer {token}",
+        session_token=None,
+    )
+
+    assert user.username == "JuyaoHuang"
+
+
+def test_enabled_auth_credentials_require_session_cookie() -> None:
+    service = AuthService(
+        {
+            "enabled": True,
+            "jwt": {"secret_key": "test-secret", "algorithm": "HS256", "expire_days": 7},
+            "github": {
+                "client_id": "client",
+                "client_secret": "secret",
+                "callback_url": "http://localhost:8430/api/auth/callback",
+            },
+            "whitelist": {"users": ["JuyaoHuang"]},
+        }
+    )
+
+    with pytest.raises(AuthTokenError, match="Missing session cookie"):
+        service.authenticate_credentials(authorization=None, session_token=None)
+
+
 def test_enabled_auth_rejects_non_whitelisted_token_subject() -> None:
     service = AuthService(
         {

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -7,6 +7,7 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from src.app import create_app
+from src.auth.oauth import GitHubUser
 
 
 def _base_config(auth_config: dict) -> dict:
@@ -71,8 +72,11 @@ async def test_auth_me_returns_default_user_when_disabled() -> None:
 
 
 @pytest.mark.asyncio
-async def test_auth_login_returns_github_authorization_url_when_enabled() -> None:
+async def test_auth_login_returns_github_authorization_url_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     app = create_app(_base_config(_enabled_auth_config()))
+    monkeypatch.setattr("src.routes.auth.secrets.token_urlsafe", lambda _size: "server-state")
 
     async with AsyncClient(
         transport=ASGITransport(app=app, raise_app_exceptions=False),
@@ -93,7 +97,124 @@ async def test_auth_login_returns_github_authorization_url_when_enabled() -> Non
     assert params["client_id"] == ["github-client"]
     assert params["redirect_uri"] == ["http://localhost:8430/api/auth/callback"]
     assert params["scope"] == ["read:user"]
-    assert params["state"] == ["nonce"]
+    assert params["state"] == ["server-state"]
+
+    set_cookie = response.headers["set-cookie"]
+    assert "atri_oauth_state=server-state" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "Max-Age=600" in set_cookie
+    assert "Path=/api/auth" in set_cookie
+    assert "SameSite=lax" in set_cookie
+    assert "Secure" not in set_cookie
+
+
+@pytest.mark.asyncio
+async def test_auth_login_sets_secure_oauth_state_cookie_for_https_callback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    auth_config = _enabled_auth_config()
+    auth_config["github"]["callback_url"] = "https://example.com/api/auth/callback"
+    app = create_app(_base_config(auth_config))
+    monkeypatch.setattr("src.routes.auth.secrets.token_urlsafe", lambda _size: "server-state")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/api/auth/login")
+
+    assert response.status_code == 200
+    assert "Secure" in response.headers["set-cookie"]
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_rejects_missing_oauth_state() -> None:
+    app = create_app(_base_config(_enabled_auth_config()))
+    app.state.auth_service.github_oauth.exchange_code_for_token = AsyncMock()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        response = await client.get("/api/auth/callback?code=github-code")
+
+    assert response.status_code == 307
+    location = urlparse(response.headers["location"])
+    assert location.path == "/auth/callback"
+    assert parse_qs(location.query)["error"] == ["invalid_state"]
+    app.state.auth_service.github_oauth.exchange_code_for_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_rejects_mismatched_oauth_state() -> None:
+    app = create_app(_base_config(_enabled_auth_config()))
+    app.state.auth_service.github_oauth.exchange_code_for_token = AsyncMock()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        client.cookies.set(
+            "atri_oauth_state",
+            "expected-state",
+            path="/api/auth",
+        )
+        response = await client.get(
+            "/api/auth/callback?code=github-code&state=actual-state",
+        )
+
+    assert response.status_code == 307
+    location = urlparse(response.headers["location"])
+    assert parse_qs(location.query)["error"] == ["invalid_state"]
+    assert "atri_oauth_state=" in response.headers["set-cookie"]
+    assert "Max-Age=0" in response.headers["set-cookie"]
+    app.state.auth_service.github_oauth.exchange_code_for_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_accepts_matching_oauth_state() -> None:
+    app = create_app(_base_config(_enabled_auth_config()))
+    app.state.auth_service.github_oauth.exchange_code_for_token = AsyncMock(
+        return_value="github-access-token"
+    )
+    app.state.auth_service.github_oauth.get_user_info = AsyncMock(
+        return_value=GitHubUser(
+            username="JuyaoHuang",
+            avatar_url="https://avatar.example/me.png",
+        )
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        client.cookies.set(
+            "atri_oauth_state",
+            "expected-state",
+            path="/api/auth",
+        )
+        response = await client.get(
+            "/api/auth/callback?code=github-code&state=expected-state",
+        )
+
+    assert response.status_code == 307
+    location = urlparse(response.headers["location"])
+    params = parse_qs(location.query)
+    assert location.path == "/auth/callback"
+    assert params["username"] == ["JuyaoHuang"]
+    assert params["avatar_url"] == ["https://avatar.example/me.png"]
+    assert "token" in params
+    assert "atri_oauth_state=" in response.headers["set-cookie"]
+    assert "Max-Age=0" in response.headers["set-cookie"]
+    app.state.auth_service.github_oauth.exchange_code_for_token.assert_awaited_once_with(
+        "github-code"
+    )
+    app.state.auth_service.github_oauth.get_user_info.assert_awaited_once_with(
+        "github-access-token"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -8,6 +8,7 @@ from httpx import ASGITransport, AsyncClient
 
 from src.app import create_app
 from src.auth.oauth import GitHubUser
+from src.auth.session import SESSION_COOKIE_NAME
 
 
 def _base_config(auth_config: dict) -> dict:
@@ -204,17 +205,59 @@ async def test_auth_callback_accepts_matching_oauth_state() -> None:
     location = urlparse(response.headers["location"])
     params = parse_qs(location.query)
     assert location.path == "/auth/callback"
-    assert params["username"] == ["JuyaoHuang"]
-    assert params["avatar_url"] == ["https://avatar.example/me.png"]
-    assert "token" in params
-    assert "atri_oauth_state=" in response.headers["set-cookie"]
-    assert "Max-Age=0" in response.headers["set-cookie"]
+    assert params["success"] == ["1"]
+    assert "token" not in params
+
+    set_cookie = "\n".join(response.headers.get_list("set-cookie"))
+    assert "atri_oauth_state=" in set_cookie
+    assert f"{SESSION_COOKIE_NAME}=" in set_cookie
+    assert "HttpOnly" in set_cookie
+    assert "Max-Age=604800" in set_cookie
+    assert "Path=/" in set_cookie
+    assert "SameSite=lax" in set_cookie
+    assert "Secure" not in set_cookie
     app.state.auth_service.github_oauth.exchange_code_for_token.assert_awaited_once_with(
         "github-code"
     )
     app.state.auth_service.github_oauth.get_user_info.assert_awaited_once_with(
         "github-access-token"
     )
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_sets_secure_session_cookie_for_https_frontend() -> None:
+    auth_config = _enabled_auth_config()
+    auth_config["frontend"]["callback_url"] = "https://example.com/auth/callback"
+    app = create_app(_base_config(auth_config))
+    app.state.auth_service.github_oauth.exchange_code_for_token = AsyncMock(
+        return_value="github-access-token"
+    )
+    app.state.auth_service.github_oauth.get_user_info = AsyncMock(
+        return_value=GitHubUser(username="JuyaoHuang")
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        client.cookies.set(
+            "atri_oauth_state",
+            "expected-state",
+            path="/api/auth",
+        )
+        response = await client.get(
+            "/api/auth/callback?code=github-code&state=expected-state",
+        )
+
+    assert response.status_code == 307
+    set_cookie = "\n".join(response.headers.get_list("set-cookie"))
+    session_cookie = next(
+        cookie for cookie in response.headers.get_list("set-cookie")
+        if cookie.startswith(f"{SESSION_COOKIE_NAME}=")
+    )
+    assert "Secure" in session_cookie
+    assert f"{SESSION_COOKIE_NAME}=" in set_cookie
 
 
 @pytest.mark.asyncio
@@ -228,16 +271,37 @@ async def test_auth_me_requires_token_when_enabled() -> None:
         response = await client.get("/api/auth/me")
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "Missing bearer token"
+    assert response.json()["detail"] == "Missing session cookie"
 
 
 @pytest.mark.asyncio
-async def test_auth_me_returns_token_user_when_enabled() -> None:
+async def test_auth_me_returns_cookie_user_when_enabled() -> None:
     app = create_app(_base_config(_enabled_auth_config()))
     token = app.state.auth_service.jwt_manager.create_token(
         "JuyaoHuang",
         avatar_url="https://avatar.example/me.png",
     )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        client.cookies.set(SESSION_COOKIE_NAME, token, path="/")
+        response = await client.get("/api/auth/me")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "username": "JuyaoHuang",
+        "avatar_url": "https://avatar.example/me.png",
+        "name": None,
+        "auth_enabled": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_auth_me_still_accepts_bearer_token_for_compatibility() -> None:
+    app = create_app(_base_config(_enabled_auth_config()))
+    token = app.state.auth_service.jwt_manager.create_token("JuyaoHuang")
 
     async with AsyncClient(
         transport=ASGITransport(app=app, raise_app_exceptions=False),
@@ -249,12 +313,24 @@ async def test_auth_me_returns_token_user_when_enabled() -> None:
         )
 
     assert response.status_code == 200
-    assert response.json() == {
-        "username": "JuyaoHuang",
-        "avatar_url": "https://avatar.example/me.png",
-        "name": None,
-        "auth_enabled": True,
-    }
+    assert response.json()["username"] == "JuyaoHuang"
+
+
+@pytest.mark.asyncio
+async def test_auth_logout_clears_session_cookie() -> None:
+    app = create_app(_base_config(_enabled_auth_config()))
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+    ) as client:
+        response = await client.post("/api/auth/logout")
+
+    assert response.status_code == 200
+    assert response.json() == {"success": True}
+    set_cookie = response.headers["set-cookie"]
+    assert f"{SESSION_COOKIE_NAME}=" in set_cookie
+    assert "Max-Age=0" in set_cookie
 
 
 @pytest.mark.asyncio
@@ -268,7 +344,7 @@ async def test_auth_middleware_rejects_protected_routes_without_token() -> None:
         response = await client.get("/api/chats")
 
     assert response.status_code == 401
-    assert response.json()["detail"] == "Missing bearer token"
+    assert response.json()["detail"] == "Missing session cookie"
 
 
 @pytest.mark.asyncio
@@ -282,10 +358,8 @@ async def test_protected_chat_routes_use_authenticated_user() -> None:
         transport=ASGITransport(app=app, raise_app_exceptions=False),
         base_url="http://test",
     ) as client:
-        response = await client.get(
-            "/api/chats",
-            headers={"Authorization": f"Bearer {token}"},
-        )
+        client.cookies.set(SESSION_COOKIE_NAME, token, path="/")
+        response = await client.get("/api/chats")
 
     assert response.status_code == 200
     assert response.json() == []


### PR DESCRIPTION
## Summary
- issue OAuth session JWTs as HttpOnly cookies instead of callback URL query tokens
- authenticate REST middleware and WebSockets from atri_session cookie with Bearer fallback for API clients
- update auth tests for cookie-based session flow
- update frontend submodule pointer to JuyaoHuang/ATRI-frontend#8 branch commit

## Verification
- uv run pytest tests/routes/test_auth.py tests/auth/test_service.py
- uv run ruff check targeted auth files
- git diff --check for targeted backend and frontend files
- deployed runtime observed /api/auth/me 200 after callback and /ws accepted without token query

Depends on frontend PR: https://github.com/JuyaoHuang/ATRI-frontend/pull/8