### PR TITLE
fix(auth): tolerate repeated oauth callbacks

### DIFF
--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -118,6 +118,18 @@ def _is_valid_oauth_state(request: Request, state: str | None) -> bool:
     return secrets.compare_digest(state, expected_state)
 
 
+def _has_valid_session_cookie(request: Request) -> bool:
+    auth_service = get_auth_service(request.app)
+    try:
+        auth_service.authenticate_credentials(
+            authorization=None,
+            session_token=request.cookies.get(SESSION_COOKIE_NAME),
+        )
+    except AuthError:
+        return False
+    return True
+
+
 @router.get("/status", response_model=AuthStatusResponse)
 async def get_auth_status(request: Request) -> AuthStatusResponse:
     auth_service = get_auth_service(request.app)
@@ -177,6 +189,12 @@ async def github_callback(
             {"error": "oauth_config"},
         )
     if not _is_valid_oauth_state(request, state):
+        if _has_valid_session_cookie(request):
+            return _redirect_with_cleared_oauth_state(
+                request,
+                auth_service.frontend_callback_url,
+                {"success": "1"},
+            )
         return _redirect_with_cleared_oauth_state(
             request,
             auth_service.frontend_callback_url,

--- a/tests/routes/test_auth.py
+++ b/tests/routes/test_auth.py
@@ -175,6 +175,64 @@ async def test_auth_callback_rejects_mismatched_oauth_state() -> None:
 
 
 @pytest.mark.asyncio
+async def test_auth_callback_skips_invalid_state_when_session_cookie_is_valid() -> None:
+    app = create_app(_base_config(_enabled_auth_config()))
+    app.state.auth_service.github_oauth.exchange_code_for_token = AsyncMock()
+    token = app.state.auth_service.jwt_manager.create_token("JuyaoHuang")
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        client.cookies.set(SESSION_COOKIE_NAME, token, path="/")
+        client.cookies.set(
+            "atri_oauth_state",
+            "expected-state",
+            path="/api/auth",
+        )
+        response = await client.get(
+            "/api/auth/callback?code=github-code&state=actual-state",
+        )
+
+    assert response.status_code == 307
+    location = urlparse(response.headers["location"])
+    params = parse_qs(location.query)
+    assert location.path == "/auth/callback"
+    assert params["success"] == ["1"]
+    assert "error" not in params
+    assert "atri_oauth_state=" in response.headers["set-cookie"]
+    assert "Max-Age=0" in response.headers["set-cookie"]
+    app.state.auth_service.github_oauth.exchange_code_for_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_auth_callback_rejects_invalid_state_when_session_cookie_is_invalid() -> None:
+    app = create_app(_base_config(_enabled_auth_config()))
+    app.state.auth_service.github_oauth.exchange_code_for_token = AsyncMock()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="http://test",
+        follow_redirects=False,
+    ) as client:
+        client.cookies.set(SESSION_COOKIE_NAME, "not-a-valid-token", path="/")
+        client.cookies.set(
+            "atri_oauth_state",
+            "expected-state",
+            path="/api/auth",
+        )
+        response = await client.get(
+            "/api/auth/callback?code=github-code&state=actual-state",
+        )
+
+    assert response.status_code == 307
+    location = urlparse(response.headers["location"])
+    assert parse_qs(location.query)["error"] == ["invalid_state"]
+    app.state.auth_service.github_oauth.exchange_code_for_token.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_auth_callback_accepts_matching_oauth_state() -> None:
     app = create_app(_base_config(_enabled_auth_config()))
     app.state.auth_service.github_oauth.exchange_code_for_token = AsyncMock(


### PR DESCRIPTION
Treat invalid OAuth state as a no-op when the browser already has a valid session cookie. This preserves state validation for unauthenticated requests while avoiding false sign-in failures from mobile/desktop UI toggles replaying an old callback.

Constraint: Do not include local deployment config or lockfile changes

Rejected: Relax OAuth state validation globally | would weaken login CSRF protection

Confidence: high

Scope-risk: narrow