### PR TITLE
fix(character): remove prompt and metadata length caps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,7 @@ data/avatars/
 .env
 .env.*
 !.env.example
+
+.claude/
+
+prompts/persona/

--- a/src/models/character.py
+++ b/src/models/character.py
@@ -32,7 +32,7 @@ class CharacterCreateRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=50)
     greeting: str | None = Field(default=None, max_length=500)
     description: str | None = Field(default=None, max_length=200)
-    system_prompt: str = Field(..., min_length=1, max_length=4000)
+    system_prompt: str = Field(..., min_length=1)
 
 
 class CharacterUpdateRequest(BaseModel):
@@ -41,7 +41,7 @@ class CharacterUpdateRequest(BaseModel):
     name: str | None = Field(default=None, min_length=1, max_length=50)
     greeting: str | None = Field(default=None, max_length=500)
     description: str | None = Field(default=None, max_length=200)
-    system_prompt: str | None = Field(default=None, min_length=1, max_length=4000)
+    system_prompt: str | None = Field(default=None, min_length=1)
 
 
 class AvatarUploadResponse(BaseModel):

--- a/src/models/character.py
+++ b/src/models/character.py
@@ -30,8 +30,8 @@ class CharacterCreateRequest(BaseModel):
 
     character_id: str | None = Field(default=None, max_length=64)
     name: str = Field(..., min_length=1, max_length=50)
-    greeting: str | None = Field(default=None, max_length=500)
-    description: str | None = Field(default=None, max_length=200)
+    greeting: str | None = None
+    description: str | None = None
     system_prompt: str = Field(..., min_length=1)
 
 
@@ -39,8 +39,8 @@ class CharacterUpdateRequest(BaseModel):
     """Payload for updating a character."""
 
     name: str | None = Field(default=None, min_length=1, max_length=50)
-    greeting: str | None = Field(default=None, max_length=500)
-    description: str | None = Field(default=None, max_length=200)
+    greeting: str | None = None
+    description: str | None = None
     system_prompt: str | None = Field(default=None, min_length=1)
 
 

--- a/tests/routes/test_characters.py
+++ b/tests/routes/test_characters.py
@@ -169,6 +169,28 @@ async def test_update_character_changes_metadata(client_and_storage):
 
 
 @pytest.mark.asyncio
+async def test_update_system_character_allows_long_system_prompt(client_and_storage):
+    client, _storage = client_and_storage
+    long_prompt = "# 角色设定\n\n" + ("御坂美琴的详细设定。\n" * 500)
+
+    response = await client.put(
+        "/api/characters/bilibili",
+        json={
+            "name": "御坂美琴",
+            "greeting": "今天也要加油。",
+            "description": "备用角色",
+            "system_prompt": long_prompt,
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["is_system"] is True
+    assert data["system_prompt"] == long_prompt.strip()
+    assert len(data["system_prompt"]) > 4000
+
+
+@pytest.mark.asyncio
 async def test_delete_character_removes_custom_persona_file(client_and_storage):
     client, storage = client_and_storage
 

--- a/tests/routes/test_characters.py
+++ b/tests/routes/test_characters.py
@@ -191,6 +191,39 @@ async def test_update_system_character_allows_long_system_prompt(client_and_stor
 
 
 @pytest.mark.asyncio
+async def test_update_character_allows_long_greeting_and_description(client_and_storage):
+    client, _storage = client_and_storage
+    long_greeting = "问候语" * 400
+    long_description = "简介" * 300
+
+    create_response = await client.post(
+        "/api/characters",
+        json={
+            "name": "LongFieldsCard",
+            "greeting": "初始问候",
+            "description": "初始描述",
+            "system_prompt": "初始设定",
+        },
+    )
+    created = create_response.json()
+
+    update_response = await client.put(
+        f"/api/characters/{created['character_id']}",
+        json={
+            "name": "LongFieldsCard",
+            "greeting": long_greeting,
+            "description": long_description,
+            "system_prompt": "更新后的设定",
+        },
+    )
+    assert update_response.status_code == 200
+
+    updated = update_response.json()
+    assert updated["greeting"] == long_greeting
+    assert updated["description"] == long_description
+
+
+@pytest.mark.asyncio
 async def test_delete_character_removes_custom_persona_file(client_and_storage):
     client, storage = client_and_storage
 


### PR DESCRIPTION
## Summary
- remove backend max length validation for character system_prompt, greeting, and description
- add route coverage for long system prompts and long greeting/description updates
- update frontend submodule pointer for precise character save error messages

## Testing
- uv run pytest tests/routes/test_characters.py -v