### PR TITLE
feat: add settings data cleanup endpoints

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -149,6 +149,7 @@ def create_app(config: dict) -> FastAPI:
     from src.routes.characters import router as characters_router
     from src.routes.chat_ws import websocket_endpoint
     from src.routes.chats import router as chats_router
+    from src.routes.data import router as data_router
     from src.routes.health import router as health_router
     from src.routes.live2d import router as live2d_router
     from src.routes.tts import router as tts_router
@@ -159,6 +160,7 @@ def create_app(config: dict) -> FastAPI:
     app.include_router(tts_router)
     app.include_router(characters_router)
     app.include_router(chats_router)
+    app.include_router(data_router)
     app.include_router(live2d_router)
 
     # Register WebSocket endpoint
@@ -171,6 +173,6 @@ def create_app(config: dict) -> FastAPI:
         StaticFiles(directory=str(avatar_dir), check_dir=False),
         name="static-avatar-assets",
     )
-    
+
     logger.info("FastAPI app created successfully")
     return app

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,5 +1,7 @@
 """Shared session-cookie constants for authentication."""
 
+from typing import Literal
+
 SESSION_COOKIE_NAME = "atri_session"
 SESSION_COOKIE_PATH = "/"
-SESSION_COOKIE_SAMESITE = "lax"
+SESSION_COOKIE_SAMESITE: Literal["lax", "strict", "none"] = "lax"

--- a/src/memory/long_term.py
+++ b/src/memory/long_term.py
@@ -399,6 +399,38 @@ class LongTermMemory:
         filtered = [r for r in items if float(r.get("score", 1.0)) >= threshold]
         return filtered[:limit]
 
+    async def delete_all(
+        self,
+        user_id: str,
+        agent_id: str,
+        run_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Delete long-term memories for the given mem0 scope.
+
+        Hosted mem0 may return an asynchronous "delete in progress" response;
+        callers should surface that as a submitted cleanup operation instead
+        of assuming immediate dashboard consistency.
+        """
+
+        kwargs: dict[str, str] = {"user_id": user_id, "agent_id": agent_id}
+        if run_id:
+            kwargs["run_id"] = run_id
+
+        try:
+            raw = await asyncio.to_thread(self._backend.delete_all, **kwargs)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "mem0.delete_all failed | user_id={} | agent_id={} | error={!r}",
+                user_id,
+                agent_id,
+                exc,
+            )
+            raise
+
+        if isinstance(raw, dict):
+            return raw
+        return {"message": str(raw)}
+
     def close(self) -> None:
         """Best-effort cleanup. No-op for SaaS; closes the Qdrant client
         handle for local_deploy so embedded rocksdb locks release promptly.

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -49,6 +49,7 @@ from __future__ import annotations
 
 import json
 import secrets
+import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
 from html import escape
@@ -65,6 +66,9 @@ from src.memory.short_term import ShortTermStore
 from src.memory.snip import snip
 
 LLMFactoryFn = Callable[[str], LLMInterface]
+_SHORT_TERM_FILENAME = "short_term_memory.json"
+_SESSIONS_SUBDIR = "sessions"
+_LEGACY_MIGRATION_MARKER = ".legacy_migrated"
 
 
 def _new_session_id() -> str:
@@ -74,6 +78,78 @@ def _new_session_id() -> str:
     """
     date = datetime.now(UTC).strftime("%Y-%m-%d")
     return f"{date}_{secrets.token_hex(4)}"
+
+
+def resolve_user_character_dir(
+    memory_config: dict[str, Any],
+    user_id: str,
+    character: str,
+    *,
+    migrate_legacy: bool = True,
+) -> Path:
+    """Return the user-scoped local memory directory for a character.
+
+    Legacy deployments stored short-term memory at
+    ``{characters_dir}/{character}``. The new path is
+    ``{characters_dir}/{user_id}/{character}``, matching chat storage and
+    mem0's ``user_id`` / ``agent_id`` scope. On first access, copy legacy
+    files into the current user's directory and keep the legacy files as a
+    fallback backup.
+    """
+
+    chars_root = Path(memory_config.get("storage", {}).get("characters_dir", "./data/characters"))
+    character_dir = chars_root / user_id / character
+    if migrate_legacy:
+        _migrate_legacy_character_memory(chars_root / character, character_dir)
+    return character_dir
+
+
+def legacy_character_dir(memory_config: dict[str, Any], character: str) -> Path:
+    """Return the pre-user-scope memory directory for ``character``."""
+
+    chars_root = Path(memory_config.get("storage", {}).get("characters_dir", "./data/characters"))
+    return chars_root / character
+
+
+def _migrate_legacy_character_memory(legacy_dir: Path, target_dir: Path) -> None:
+    if not legacy_dir.is_dir():
+        return
+
+    migrated_items: list[str] = []
+    handled_legacy = False
+    marker_path = target_dir / _LEGACY_MIGRATION_MARKER
+    if marker_path.exists():
+        return
+
+    legacy_short_term = legacy_dir / _SHORT_TERM_FILENAME
+    target_short_term = target_dir / _SHORT_TERM_FILENAME
+    if legacy_short_term.is_file():
+        if not target_short_term.exists():
+            target_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(legacy_short_term, target_short_term)
+            migrated_items.append(_SHORT_TERM_FILENAME)
+        handled_legacy = target_short_term.exists()
+
+    legacy_sessions = legacy_dir / _SESSIONS_SUBDIR
+    target_sessions = target_dir / _SESSIONS_SUBDIR
+    if legacy_sessions.is_dir():
+        if not target_sessions.exists():
+            target_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(legacy_sessions, target_sessions)
+            migrated_items.append(_SESSIONS_SUBDIR)
+        handled_legacy = handled_legacy or target_sessions.exists()
+
+    if handled_legacy:
+        target_dir.mkdir(parents=True, exist_ok=True)
+        marker_path.touch(exist_ok=True)
+
+    if migrated_items:
+        logger.info(
+            "Legacy character memory copied | legacy={} | target={} | items={}",
+            legacy_dir,
+            target_dir,
+            ",".join(migrated_items),
+        )
 
 
 def _is_valid_round(ai_msg: dict[str, Any]) -> bool:
@@ -223,10 +299,7 @@ class MemoryManager:
         self.l4_role: str = compressor_cfg.get("l4_role", "l4_compact")
 
         if character_dir is None:
-            chars_root = Path(
-                memory_config.get("storage", {}).get("characters_dir", "./data/characters")
-            )
-            character_dir = chars_root / character
+            character_dir = resolve_user_character_dir(memory_config, user_id, character)
         self.character_dir = Path(character_dir)
 
         self._active_session_id: str | None = None
@@ -300,6 +373,41 @@ class MemoryManager:
     @property
     def active_session_id(self) -> str | None:
         return self._active_session_id
+
+    def reset_short_term(self) -> None:
+        """Hot-clear the in-memory short-term state and remove its file.
+
+        The manager remains usable after this call: the active session id is
+        preserved when present, and the next round starts with an empty
+        ``short_term_memory`` skeleton instead of restoring old context.
+        """
+
+        session_id = self._active_session_id or _new_session_id()
+        self._active_session_id = session_id
+        if self.short_term_store is None:
+            self.short_term_store = ShortTermStore(self.character_dir, session_id, self.character)
+        else:
+            self.short_term_store.session_id = session_id
+        if self.chat_history is None:
+            self.chat_history = ChatHistoryWriter(self.character_dir, session_id, self.character)
+
+        short_term_path = self.short_term_store.path
+        tmp_path = short_term_path.with_suffix(".json.tmp")
+        for path in (short_term_path, tmp_path):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning("short_term delete failed | path={} | error={!r}", path, exc)
+        (self.character_dir / _LEGACY_MIGRATION_MARKER).touch(exist_ok=True)
+
+        self._state = ShortTermStore.get_skeleton(session_id, self.character)
+        self._dirty = False
+        logger.info(
+            "MemoryManager short-term state reset | character={} | user_id={} | session_id={}",
+            self.character,
+            self.user_id,
+            session_id,
+        )
 
     # ------------------------------------------------------------------
     # Explicit session lifecycle (US-MEM-007)

--- a/src/routes/data.py
+++ b/src/routes/data.py
@@ -1,0 +1,148 @@
+"""Data maintenance REST API routes."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, status
+from loguru import logger
+from pydantic import BaseModel, Field
+
+from src.auth import get_request_user_id
+from src.memory.long_term import LongTermMemory
+from src.service_context import ServiceContext, _safe_build_long_term
+
+router = APIRouter(prefix="/api/data", tags=["data"])
+
+_SHORT_TERM_FILENAME = "short_term_memory.json"
+
+
+class DataCleanupResponse(BaseModel):
+    """Response for data cleanup operations."""
+
+    character_id: str
+    user_id: str
+    target: str
+    status: str
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)
+
+
+def _service_context(request: Request) -> ServiceContext:
+    context = getattr(request.app.state, "service_context", None)
+    if not isinstance(context, ServiceContext):
+        context = ServiceContext(getattr(request.app.state, "config", {}))
+        request.app.state.service_context = context
+    return context
+
+
+async def _unlink_if_exists(path: Path) -> bool:
+    def _delete() -> bool:
+        if not path.exists():
+            return False
+        path.unlink()
+        return True
+
+    return await asyncio.to_thread(_delete)
+
+
+def _get_long_term_memory(request: Request, character_id: str, user_id: str) -> LongTermMemory:
+    context = _service_context(request)
+    cached = context.get_cached_long_term_memory(character_id, user_id)
+    if cached is not None:
+        return cached
+
+    config = getattr(request.app.state, "config", {})
+    long_term = _safe_build_long_term(config.get("memory", {}).get("mem0", {}))
+    if long_term is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Long-term memory backend is not available",
+        )
+    return long_term
+
+
+@router.delete(
+    "/characters/{character_id}/short-term-memory",
+    response_model=DataCleanupResponse,
+)
+async def clear_short_term_memory(
+    character_id: str,
+    request: Request,
+) -> DataCleanupResponse:
+    """Clear short-term memory for current user and character, hot if cached."""
+
+    user_id = get_request_user_id(request)
+    context = _service_context(request)
+    character_dir = Path(context.get_character_memory_dir(character_id, user_id))
+    short_term_path = character_dir / _SHORT_TERM_FILENAME
+    tmp_path = short_term_path.with_suffix(".json.tmp")
+
+    removed_short_term = await _unlink_if_exists(short_term_path)
+    removed_tmp = await _unlink_if_exists(tmp_path)
+    cache_reset = context.reset_short_term_memory(character_id, user_id)
+
+    legacy_path = Path(context.get_legacy_character_memory_dir(character_id)) / _SHORT_TERM_FILENAME
+
+    logger.info(
+        "Short-term memory cleared | character={} | user_id={} | removed={} | cache_reset={}",
+        character_id,
+        user_id,
+        removed_short_term,
+        cache_reset,
+    )
+
+    return DataCleanupResponse(
+        character_id=character_id,
+        user_id=user_id,
+        target="short_term_memory",
+        status="cleared",
+        message="短期记忆已清理，并已同步当前运行中的记忆状态。",
+        details={
+            "path": str(short_term_path),
+            "legacy_path": str(legacy_path),
+            "removed_file": removed_short_term,
+            "removed_tmp": removed_tmp,
+            "cache_reset": cache_reset,
+        },
+    )
+
+
+@router.delete(
+    "/characters/{character_id}/long-term-memory",
+    response_model=DataCleanupResponse,
+)
+async def clear_long_term_memory(
+    character_id: str,
+    request: Request,
+) -> DataCleanupResponse:
+    """Submit long-term memory deletion for current user and character."""
+
+    user_id = get_request_user_id(request)
+    long_term = _get_long_term_memory(request, character_id, user_id)
+
+    try:
+        result = await long_term.delete_all(user_id=user_id, agent_id=character_id)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail=f"Long-term memory deletion failed: {exc}",
+        ) from exc
+
+    logger.info(
+        "Long-term memory delete submitted | character={} | user_id={} | result={}",
+        character_id,
+        user_id,
+        result,
+    )
+
+    return DataCleanupResponse(
+        character_id=character_id,
+        user_id=user_id,
+        target="long_term_memory",
+        status="submitted",
+        message="长期记忆删除已提交，可能稍后完成。",
+        details={"mem0": result},
+    )

--- a/src/service_context.py
+++ b/src/service_context.py
@@ -52,7 +52,7 @@ from src.agent.persona import load_persona
 from src.llm.factory import create_from_role
 from src.llm.interface import LLMInterface
 from src.memory.long_term import LongTermMemory
-from src.memory.manager import MemoryManager
+from src.memory.manager import MemoryManager, legacy_character_dir, resolve_user_character_dir
 
 
 def _safe_build_long_term(mem0_config: dict[str, Any]) -> LongTermMemory | None:
@@ -169,6 +169,45 @@ class ServiceContext:
             "on" if long_term is not None else "off",
         )
         return agent
+
+    def get_character_memory_dir(self, character_id: str, user_id: str) -> str:
+        """Return and migrate the user-scoped local memory directory path."""
+
+        memory_config = self.config.get("memory", {})
+        return str(resolve_user_character_dir(memory_config, user_id, character_id))
+
+    def get_legacy_character_memory_dir(self, character_id: str) -> str:
+        """Return the legacy pre-user-scope local memory directory path."""
+
+        memory_config = self.config.get("memory", {})
+        return str(legacy_character_dir(memory_config, character_id))
+
+    def reset_short_term_memory(self, character_id: str, user_id: str) -> bool:
+        """Hot-clear cached short-term memory for ``(character_id, user_id)``.
+
+        Returns ``True`` when a cached agent existed and was reset. A ``False``
+        return means the route only needs to delete persisted files because no
+        in-process memory state is alive yet.
+        """
+
+        agent = self._agents.get((character_id, user_id))
+        if agent is None:
+            return False
+
+        agent.memory_manager.reset_short_term()
+        return True
+
+    def get_cached_long_term_memory(
+        self,
+        character_id: str,
+        user_id: str,
+    ) -> LongTermMemory | None:
+        """Return a cached agent's long-term memory handle, if one exists."""
+
+        agent = self._agents.get((character_id, user_id))
+        if agent is None:
+            return None
+        return agent.memory_manager.long_term
 
     async def close_all(self) -> None:
         """Flush every cached agent's session and release long-term handles.

--- a/tests/memory/test_long_term.py
+++ b/tests/memory/test_long_term.py
@@ -285,6 +285,27 @@ async def test_add_swallows_backend_errors() -> None:
         await ltm.add([], user_id="a", agent_id="b", run_id="c")
 
 
+@pytest.mark.asyncio
+async def test_delete_all_delegates_to_underlying_backend() -> None:
+    """delete_all scopes deletion to the current mem0 user/agent pair."""
+
+    with patch("mem0.MemoryClient") as mock_client_cls:
+        mock_backend = MagicMock()
+        mock_backend.delete_all = MagicMock(
+            return_value={
+                "message": "Delete in progress. This may take some time.",
+                "event_id": "evt-1",
+            }
+        )
+        mock_client_cls.return_value = mock_backend
+
+        ltm = LongTermMemory(_sdk_config())
+        result = await ltm.delete_all(user_id="alice", agent_id="atri")
+
+        mock_backend.delete_all.assert_called_once_with(user_id="alice", agent_id="atri")
+        assert result["event_id"] == "evt-1"
+
+
 # ---------------------------------------------------------------------------
 # Config translator helpers
 # 配置翻译器辅助函数

--- a/tests/memory/test_manager.py
+++ b/tests/memory/test_manager.py
@@ -40,7 +40,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.memory.chat_history import ChatHistoryWriter
-from src.memory.manager import MemoryManager, _is_valid_round
+from src.memory.manager import MemoryManager, _is_valid_round, resolve_user_character_dir
 from src.memory.short_term import ShortTermStore
 
 # ---------------------------------------------------------------------------
@@ -107,6 +107,105 @@ def _new_manager(tmp_path: Path, factory=None) -> MemoryManager:
         user_id="alice",
         character_dir=tmp_path,
     )
+
+
+def test_resolve_user_character_dir_copies_legacy_short_term(tmp_path: Path) -> None:
+    characters_root = tmp_path / "characters"
+    legacy_dir = characters_root / "atri"
+    legacy_dir.mkdir(parents=True)
+    legacy_payload = {
+        "session_id": "legacy-session",
+        "character": "atri",
+        "total_rounds": 3,
+        "meta_blocks": [],
+        "active_blocks": [],
+        "recent_messages": [{"role": "human", "content": "legacy"}],
+    }
+    (legacy_dir / "short_term_memory.json").write_text(
+        json.dumps(legacy_payload, ensure_ascii=False),
+        encoding="utf-8",
+    )
+
+    target = resolve_user_character_dir(
+        {"storage": {"characters_dir": str(characters_root)}},
+        "alice",
+        "atri",
+    )
+
+    assert target == characters_root / "alice" / "atri"
+    copied = json.loads((target / "short_term_memory.json").read_text(encoding="utf-8"))
+    assert copied["session_id"] == "legacy-session"
+    assert (legacy_dir / "short_term_memory.json").is_file()
+
+
+def test_resolve_user_character_dir_does_not_remigrate_after_marker(tmp_path: Path) -> None:
+    characters_root = tmp_path / "characters"
+    legacy_dir = characters_root / "atri"
+    target_dir = characters_root / "alice" / "atri"
+    legacy_dir.mkdir(parents=True)
+    target_dir.mkdir(parents=True)
+    (target_dir / ".legacy_migrated").touch()
+    (legacy_dir / "short_term_memory.json").write_text(
+        json.dumps({"session_id": "legacy-session"}),
+        encoding="utf-8",
+    )
+
+    target = resolve_user_character_dir(
+        {"storage": {"characters_dir": str(characters_root)}},
+        "alice",
+        "atri",
+    )
+
+    assert target == target_dir
+    assert not (target / "short_term_memory.json").exists()
+
+
+@pytest.mark.asyncio
+async def test_reset_short_term_hot_clears_memory_and_file(tmp_path: Path) -> None:
+    mgr = _new_manager(tmp_path)
+    await mgr.on_round_complete(_human("old memory"), _ai("old reply"))
+    assert mgr.short_term_store is not None
+    assert mgr.short_term_store.path.is_file()
+    assert mgr.state["recent_messages"]
+
+    mgr.reset_short_term()
+
+    assert mgr.short_term_store is not None
+    assert not mgr.short_term_store.path.exists()
+    assert mgr.state["total_rounds"] == 0
+    assert mgr.state["recent_messages"] == []
+    assert mgr.state["active_blocks"] == []
+    assert mgr.state["meta_blocks"] == []
+    assert (tmp_path / ".legacy_migrated").is_file()
+
+
+def test_reset_short_term_marks_legacy_migration_complete_for_new_manager(tmp_path: Path) -> None:
+    characters_root = tmp_path / "characters"
+    legacy_dir = characters_root / "atri"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "short_term_memory.json").write_text(
+        json.dumps(
+            {
+                "session_id": "legacy-session",
+                "character": "atri",
+                "total_rounds": 3,
+                "meta_blocks": [],
+                "active_blocks": [],
+                "recent_messages": [{"role": "human", "content": "legacy"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+    config = {"storage": {"characters_dir": str(characters_root)}}
+    mgr = MemoryManager(config, _make_factory(), character="atri", user_id="alice")
+
+    assert mgr.short_term_store is not None
+    assert mgr.short_term_store.path.is_file()
+    mgr.reset_short_term()
+
+    assert not mgr.short_term_store.path.exists()
+    MemoryManager(config, _make_factory(), character="atri", user_id="alice")
+    assert not (characters_root / "alice" / "atri" / "short_term_memory.json").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/routes/test-exe.md
+++ b/tests/routes/test-exe.md
@@ -232,7 +232,23 @@ uv run ruff check . --fix
 
 ---
 
-## 8. 验收清单
+## 8. 数据清理接口验收
+
+验证 `/api/data` 的角色级数据清理能力：
+
+```bash
+uv run pytest tests/memory/test_manager.py tests/memory/test_long_term.py tests/routes/test_data.py -q
+```
+
+**期望结果**:
+- 全部测试通过
+- 短期记忆删除用户级 `short_term_memory.json`，并重置进程内 MemoryManager 状态
+- legacy `data/characters/{character_id}` 只迁移一次，清理后不会再次恢复旧短期记忆
+- 长期记忆调用 mem0 `delete_all(user_id=当前用户, agent_id=角色ID)` 并返回“已提交”语义
+
+---
+
+## 9. 验收清单
 
 - [ ] 快速自检通过（60+ 个 mock 测试）
 - [ ] 全量测试通过（259 passed, 4 deselected）
@@ -241,11 +257,12 @@ uv run ruff check . --fix
 - [ ] WebSocket 手动测试通过（ping/pong + 文本输入 + 错误处理）
 - [ ] mypy 类型检查通过
 - [ ] ruff 格式化和 lint 通过
+- [ ] 数据清理接口验收通过
 - [ ] 测试数据已清理
 
 ---
 
-## 9. 故障排查
+## 10. 故障排查
 
 ### 问题 1: Live 测试失败 - API Key 错误
 
@@ -293,6 +310,6 @@ lsof -ti:8000 | xargs kill -9
 
 ---
 
-## 10. 完成标志
+## 11. 完成标志
 
 当以上所有验收清单项都勾选完成时，Phase 5 FastAPI 服务层实现完成，可以提交 PR。

--- a/tests/routes/test_data.py
+++ b/tests/routes/test_data.py
@@ -1,0 +1,163 @@
+"""Tests for data maintenance routes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from src.app import create_app
+from src.memory.manager import MemoryManager
+from src.utils.config_loader import load_config
+
+
+def _test_config(tmp_path: Path) -> dict[str, Any]:
+    config = load_config("config.yaml")
+    config["memory"]["storage"]["characters_dir"] = str(tmp_path / "characters")
+    config["memory"]["mem0"] = {"mode": "sdk", "sdk": {"api_key": "m0-test"}}
+    config["storage"] = {"mode": "json", "json": {"base_path": str(tmp_path / "chats")}}
+    config["auth"] = {"enabled": False}
+    return config
+
+
+def _make_memory_manager(config: dict[str, Any]) -> MemoryManager:
+    return MemoryManager(
+        config["memory"],
+        lambda _role: AsyncMock(),
+        character="atri",
+        user_id="default",
+        long_term=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_clear_short_term_memory_deletes_user_scoped_file_and_hot_cache(
+    tmp_path: Path,
+) -> None:
+    config = _test_config(tmp_path)
+    app = create_app(config)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            manager = _make_memory_manager(config)
+            app.state.service_context._agents[("atri", "default")] = SimpleNamespace(
+                memory_manager=manager
+            )
+            assert manager.short_term_store is not None
+
+            manager._state = {
+                "session_id": manager.active_session_id,
+                "character": "atri",
+                "updated_at": "2026-01-01T00:00:00Z",
+                "total_rounds": 1,
+                "meta_blocks": [],
+                "active_blocks": [],
+                "recent_messages": [{"role": "human", "content": "old"}],
+            }
+            manager.short_term_store.save(manager.state)
+            assert manager.short_term_store.path.is_file()
+
+            response = await client.delete("/api/data/characters/atri/short-term-memory")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["target"] == "short_term_memory"
+            assert data["details"]["cache_reset"] is True
+            assert not manager.short_term_store.path.exists()
+            assert manager.state["total_rounds"] == 0
+            assert manager.state["recent_messages"] == []
+
+
+@pytest.mark.asyncio
+async def test_clear_short_term_memory_migrates_legacy_file_before_delete(tmp_path: Path) -> None:
+    config = _test_config(tmp_path)
+    characters_root = Path(config["memory"]["storage"]["characters_dir"])
+    legacy_dir = characters_root / "atri"
+    legacy_dir.mkdir(parents=True)
+    (legacy_dir / "short_term_memory.json").write_text(
+        json.dumps(
+            {
+                "session_id": "legacy",
+                "character": "atri",
+                "total_rounds": 1,
+                "meta_blocks": [],
+                "active_blocks": [],
+                "recent_messages": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    app = create_app(config)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            response = await client.delete("/api/data/characters/atri/short-term-memory")
+
+    assert response.status_code == 200
+    user_scoped_path = characters_root / "default" / "atri" / "short_term_memory.json"
+    assert not user_scoped_path.exists()
+    assert (legacy_dir / "short_term_memory.json").is_file()
+    assert (characters_root / "default" / "atri" / ".legacy_migrated").is_file()
+
+
+@pytest.mark.asyncio
+async def test_clear_short_term_memory_does_not_restore_previously_migrated_legacy(
+    tmp_path: Path,
+) -> None:
+    config = _test_config(tmp_path)
+    characters_root = Path(config["memory"]["storage"]["characters_dir"])
+    legacy_dir = characters_root / "atri"
+    user_dir = characters_root / "default" / "atri"
+    legacy_dir.mkdir(parents=True)
+    user_dir.mkdir(parents=True)
+    (legacy_dir / "short_term_memory.json").write_text(
+        json.dumps({"session_id": "legacy"}),
+        encoding="utf-8",
+    )
+    (user_dir / "short_term_memory.json").write_text(
+        json.dumps({"session_id": "already-migrated"}),
+        encoding="utf-8",
+    )
+
+    app = create_app(config)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            response = await client.delete("/api/data/characters/atri/short-term-memory")
+            assert response.status_code == 200
+
+            new_manager = _make_memory_manager(config)
+
+    assert new_manager.short_term_store is not None
+    assert not new_manager.short_term_store.path.exists()
+
+
+@pytest.mark.asyncio
+async def test_clear_long_term_memory_submits_mem0_delete(tmp_path: Path) -> None:
+    config = _test_config(tmp_path)
+    app = create_app(config)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            mock_long_term = AsyncMock()
+            mock_long_term.delete_all.return_value = {
+                "message": "Delete in progress. This may take some time.",
+                "event_id": "evt-test",
+            }
+            mock_long_term.close = lambda: None
+            app.state.service_context._agents[("atri", "default")] = SimpleNamespace(
+                memory_manager=SimpleNamespace(long_term=mock_long_term)
+            )
+
+            response = await client.delete("/api/data/characters/atri/long-term-memory")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["status"] == "submitted"
+            assert data["message"] == "长期记忆删除已提交，可能稍后完成。"
+            assert data["details"]["mem0"]["event_id"] == "evt-test"
+            mock_long_term.delete_all.assert_awaited_once_with(user_id="default", agent_id="atri")


### PR DESCRIPTION
## Summary
- add /api/data endpoints for character-scoped short-term and long-term memory cleanup
- migrate short-term memory to user_id/character_id paths with legacy copy-once support
- hot-reset cached MemoryManager state and add mem0 delete_all support
- update route test execution docs

## Verification
- uv run ruff check .
- uv run python -m mypy src/ --ignore-missing-imports
- uv run pytest tests/memory/test_manager.py tests/memory/test_long_term.py tests/routes/test_data.py -q