### PR TITLE
feat: add memory retrieval policy cache

### DIFF
--- a/config/memory_config.yaml
+++ b/config/memory_config.yaml
@@ -114,6 +114,27 @@ mem0:
     threshold: 0.3
     rerank: false
 
+  # Long-term retrieval policy. Missing this block keeps legacy behavior
+  # (search every turn); this default saves mem0 retrieval quota.
+  retrieval:
+    enabled: true
+    policy: hybrid                  # always | interval | triggered | hybrid
+    interval_turns: 10              # fallback search after N valid rounds
+    min_query_chars: 6              # skip very short inputs
+    trigger_keywords:
+      - 记得
+      - 还记得
+      - 之前
+      - 上次
+      - 我说过
+      - 我的偏好
+      - 我的信息
+    cache:
+      enabled: true
+      backend: memory               # process-local cache, no external service
+      ttl_seconds: 1800
+      max_entries: 512
+
 # --- Storage paths ---
 storage:
   characters_dir: ./data/characters

--- a/docs/developments/module-design/记忆系统设计讨论.md
+++ b/docs/developments/module-design/记忆系统设计讨论.md
@@ -906,9 +906,25 @@ mem0:
     limit: 5
     threshold: 0.3
     rerank: false
+  retrieval:
+    enabled: true
+    policy: hybrid              # always | interval | triggered | hybrid
+    interval_turns: 10
+    min_query_chars: 6
+    trigger_keywords: ["记得", "还记得", "之前", "上次", "我说过", "我的偏好", "我的信息"]
+    cache:
+      enabled: true
+      backend: memory
+      ttl_seconds: 1800
+      max_entries: 512
 ```
 
 **兼容性说明：** `sdk` 和 `local_deploy` 两种模式下 `limit` / `threshold` 参数语义一致；`rerank` 在 SaaS 端可能由 mem0 内部算法替代（非用户可控），`local_deploy` 下需额外配 reranker provider 才能启用。
+
+**检索额度控制：**
+- 缺少 `mem0.retrieval` 时保持旧行为：每轮都检索。
+- 默认 `hybrid`：命中关键词立即检索；否则按 `interval_turns` 做兜底检索；短输入低于 `min_query_chars` 直接跳过。
+- `cache.backend=memory` 是进程内 TTL 缓存，只减少同进程重复查询；不跨进程、不跨重启。
 
 **调优触发条件**（留给上线后实测）：
 - 用户反馈"AI 记不住我说过的话" → 降低 threshold 或提高 limit

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,5 +1,7 @@
 """Shared session-cookie constants for authentication."""
 
+from typing import Literal
+
 SESSION_COOKIE_NAME = "atri_session"
 SESSION_COOKIE_PATH = "/"
-SESSION_COOKIE_SAMESITE = "lax"
+SESSION_COOKIE_SAMESITE: Literal["lax", "strict", "none"] = "lax"

--- a/src/memory/long_term.py
+++ b/src/memory/long_term.py
@@ -55,6 +55,8 @@ from typing import Any
 
 from loguru import logger
 
+from src.memory.search_cache import SearchCache
+
 
 def _is_unresolved_placeholder(value: Any) -> bool:
     """Return True when ``value`` still looks like ``${VAR}`` post-dotenv load.
@@ -289,6 +291,10 @@ class LongTermMemory:
             raise ValueError(f"mem0.mode must be 'sdk' or 'local_deploy', got {mode!r}")
         self.mode: str = mode
         self._backend: Any = None
+        search_cfg = mem0_config.get("search") or {}
+        self.default_search_limit = int(search_cfg.get("limit", 5))
+        self.default_search_threshold = float(search_cfg.get("threshold", 0.3))
+        self._search_cache = self._build_search_cache(mem0_config)
 
         if mode == "sdk":
             sdk_cfg = mem0_config.get("sdk") or {}
@@ -308,6 +314,24 @@ class LongTermMemory:
             self._backend = Memory.from_config(translated)
 
         logger.info(f"LongTermMemory ready | mode={mode}")
+
+    def _build_search_cache(self, mem0_config: dict[str, Any]) -> SearchCache | None:
+        retrieval_cfg = mem0_config.get("retrieval")
+        if not isinstance(retrieval_cfg, dict):
+            return None
+        cache_cfg = retrieval_cfg.get("cache")
+        if not isinstance(cache_cfg, dict) or not cache_cfg.get("enabled", False):
+            return None
+
+        backend = str(cache_cfg.get("backend", "memory")).strip().lower()
+        if backend != "memory":
+            logger.warning(f"Unsupported mem0 search cache backend {backend!r}; cache disabled")
+            return None
+
+        return SearchCache(
+            ttl_seconds=int(cache_cfg.get("ttl_seconds", 1800)),
+            max_entries=int(cache_cfg.get("max_entries", 512)),
+        )
 
     # ------------------------------------------------------------------
     # Public API
@@ -345,6 +369,7 @@ class LongTermMemory:
                 agent_id=agent_id,
                 run_id=run_id,
             )
+            self.invalidate_search_cache(user_id, agent_id)
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"mem0.add failed | {exc!r}")
 
@@ -353,8 +378,8 @@ class LongTermMemory:
         query: str,
         user_id: str,
         agent_id: str,
-        limit: int = 5,
-        threshold: float = 0.3,
+        limit: int | None = None,
+        threshold: float | None = None,
     ) -> list[dict[str, Any]]:
         """Retrieve related memories for the current user/agent pair.
 
@@ -373,13 +398,30 @@ class LongTermMemory:
         后端错误时返回 ``[]`` 并记录 WARNING，从而让 LLM 调用在不带长期
         上下文的情况下继续推进，而不是让整轮失败。
         """
+        resolved_limit = self.default_search_limit if limit is None else int(limit)
+        resolved_threshold = (
+            self.default_search_threshold if threshold is None else float(threshold)
+        )
+        cache_key = None
+        if self._search_cache is not None:
+            cache_key = SearchCache.make_key(
+                user_id=user_id,
+                agent_id=agent_id,
+                query=query,
+                limit=resolved_limit,
+                threshold=resolved_threshold,
+            )
+            cached = self._search_cache.get(cache_key)
+            if cached is not None:
+                return cached
+
         filters = {"user_id": user_id, "agent_id": agent_id}
         try:
             raw = await asyncio.to_thread(
                 self._backend.search,
                 query,
                 filters=filters,
-                top_k=limit,
+                top_k=resolved_limit,
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning(f"mem0.search failed | {exc!r}")
@@ -396,8 +438,16 @@ class LongTermMemory:
         else:
             items = []
 
-        filtered = [r for r in items if float(r.get("score", 1.0)) >= threshold]
-        return filtered[:limit]
+        filtered = [r for r in items if float(r.get("score", 1.0)) >= resolved_threshold]
+        results = filtered[:resolved_limit]
+        if self._search_cache is not None and cache_key is not None:
+            self._search_cache.set(cache_key, results)
+        return results
+
+    def invalidate_search_cache(self, user_id: str, agent_id: str) -> None:
+        """Drop cached search results for one user/agent scope."""
+        if self._search_cache is not None:
+            self._search_cache.invalidate_scope(user_id=user_id, agent_id=agent_id)
 
     def close(self) -> None:
         """Best-effort cleanup. No-op for SaaS; closes the Qdrant client

--- a/src/memory/long_term.py
+++ b/src/memory/long_term.py
@@ -55,7 +55,7 @@ from typing import Any
 
 from loguru import logger
 
-from src.memory.search_cache import SearchCache
+from src.memory.search_cache import SearchCache, normalize_search_query
 
 
 def _is_unresolved_placeholder(value: Any) -> bool:
@@ -402,12 +402,13 @@ class LongTermMemory:
         resolved_threshold = (
             self.default_search_threshold if threshold is None else float(threshold)
         )
+        normalized_query = normalize_search_query(query)
         cache_key = None
         if self._search_cache is not None:
             cache_key = SearchCache.make_key(
                 user_id=user_id,
                 agent_id=agent_id,
-                query=query,
+                query=normalized_query,
                 limit=resolved_limit,
                 threshold=resolved_threshold,
             )
@@ -419,7 +420,7 @@ class LongTermMemory:
         try:
             raw = await asyncio.to_thread(
                 self._backend.search,
-                query,
+                normalized_query,
                 filters=filters,
                 top_k=resolved_limit,
             )

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -61,6 +61,7 @@ from src.llm.interface import LLMInterface
 from src.memory.chat_history import ChatHistoryWriter
 from src.memory.compressor import l3_collapse, l4_super_compact
 from src.memory.long_term import LongTermMemory
+from src.memory.retrieval_policy import LongTermRetrievalPolicy
 from src.memory.short_term import ShortTermStore
 from src.memory.snip import snip
 
@@ -221,6 +222,14 @@ class MemoryManager:
         self.snip_config: dict[str, Any] = dict(short_term_cfg.get("snip", {}))
         self.l3_role: str = compressor_cfg.get("l3_role", "l3_compress")
         self.l4_role: str = compressor_cfg.get("l4_role", "l4_compact")
+        mem0_cfg = memory_config.get("mem0") or {}
+        search_cfg = mem0_cfg.get("search") if isinstance(mem0_cfg, dict) else {}
+        search_cfg = search_cfg if isinstance(search_cfg, dict) else {}
+        self.long_term_search_limit: int = int(search_cfg.get("limit", 5))
+        self.long_term_retrieval_policy = LongTermRetrievalPolicy.from_mem0_config(
+            mem0_cfg if isinstance(mem0_cfg, dict) else {}
+        )
+        self._last_long_term_search_round: int | None = None
 
         if character_dir is None:
             chars_root = Path(
@@ -745,7 +754,7 @@ class MemoryManager:
     async def search_long_term(
         self,
         query: str,
-        limit: int = 5,
+        limit: int | None = None,
     ) -> list[dict[str, Any]]:
         """Retrieve related long-term facts for the current user/agent pair.
 
@@ -761,11 +770,26 @@ class MemoryManager:
         """
         if self.long_term is None:
             return []
+        total_rounds = int(self._state.get("total_rounds", 0)) if self._state is not None else 0
+        decision = self.long_term_retrieval_policy.decide(
+            query,
+            current_round=total_rounds,
+            last_search_round=self._last_long_term_search_round,
+        )
+        if not decision.should_search:
+            logger.debug(
+                f"long-term retrieval skipped | reason={decision.reason} | "
+                f"character={self.character} | user_id={self.user_id}"
+            )
+            return []
+
+        resolved_limit = self.long_term_search_limit if limit is None else int(limit)
+        self._last_long_term_search_round = total_rounds
         return await self.long_term.search(
             query,
             user_id=self.user_id,
             agent_id=self.character,
-            limit=limit,
+            limit=resolved_limit,
         )
 
     # ------------------------------------------------------------------

--- a/src/memory/retrieval_policy.py
+++ b/src/memory/retrieval_policy.py
@@ -1,0 +1,99 @@
+"""Long-term memory retrieval policy.
+
+This module decides whether a chat turn should call ``mem0.search`` before
+building the LLM context. It is intentionally pure so quota-saving behavior can
+be tested without touching mem0.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+VALID_POLICIES = {"always", "interval", "triggered", "hybrid"}
+
+
+@dataclass(frozen=True)
+class RetrievalDecision:
+    should_search: bool
+    reason: str
+
+
+@dataclass(frozen=True)
+class LongTermRetrievalPolicy:
+    enabled: bool = True
+    policy: str = "always"
+    interval_turns: int = 10
+    min_query_chars: int = 0
+    trigger_keywords: tuple[str, ...] = field(default_factory=tuple)
+
+    @classmethod
+    def from_mem0_config(cls, mem0_config: dict[str, Any]) -> LongTermRetrievalPolicy:
+        retrieval_cfg = mem0_config.get("retrieval")
+        if not isinstance(retrieval_cfg, dict):
+            return cls()
+
+        policy = str(retrieval_cfg.get("policy", "always")).strip().lower()
+        if policy not in VALID_POLICIES:
+            raise ValueError(
+                f"mem0.retrieval.policy must be one of {sorted(VALID_POLICIES)}, got {policy!r}"
+            )
+
+        raw_keywords = retrieval_cfg.get("trigger_keywords") or ()
+        keywords = tuple(
+            str(keyword).strip()
+            for keyword in raw_keywords
+            if isinstance(keyword, str) and keyword.strip()
+        )
+
+        return cls(
+            enabled=bool(retrieval_cfg.get("enabled", True)),
+            policy=policy,
+            interval_turns=max(1, int(retrieval_cfg.get("interval_turns", 10))),
+            min_query_chars=max(0, int(retrieval_cfg.get("min_query_chars", 0))),
+            trigger_keywords=keywords,
+        )
+
+    def decide(
+        self,
+        query: str,
+        *,
+        current_round: int,
+        last_search_round: int | None,
+    ) -> RetrievalDecision:
+        text = " ".join(query.strip().split())
+        if not self.enabled:
+            return RetrievalDecision(False, "disabled")
+        if not text:
+            return RetrievalDecision(False, "empty_query")
+        if len(text) < self.min_query_chars:
+            return RetrievalDecision(False, "short_query")
+
+        if self.policy == "always":
+            return RetrievalDecision(True, "always")
+
+        trigger_matched = self._matches_trigger(text)
+        interval_due = self._is_interval_due(current_round, last_search_round)
+
+        if self.policy == "triggered":
+            return RetrievalDecision(
+                trigger_matched, "triggered" if trigger_matched else "no_trigger"
+            )
+        if self.policy == "interval":
+            return RetrievalDecision(interval_due, "interval" if interval_due else "interval_skip")
+
+        should_search = trigger_matched or interval_due
+        if trigger_matched:
+            return RetrievalDecision(True, "hybrid_trigger")
+        if interval_due:
+            return RetrievalDecision(True, "hybrid_interval")
+        return RetrievalDecision(should_search, "hybrid_skip")
+
+    def _matches_trigger(self, text: str) -> bool:
+        folded = text.casefold()
+        return any(keyword.casefold() in folded for keyword in self.trigger_keywords)
+
+    def _is_interval_due(self, current_round: int, last_search_round: int | None) -> bool:
+        if last_search_round is None:
+            return True
+        return current_round - last_search_round >= self.interval_turns

--- a/src/memory/retrieval_policy.py
+++ b/src/memory/retrieval_policy.py
@@ -13,6 +13,25 @@ from typing import Any
 VALID_POLICIES = {"always", "interval", "triggered", "hybrid"}
 
 
+def _parse_trigger_keywords(value: Any) -> tuple[str, ...]:
+    if value is None:
+        return ()
+    if isinstance(value, str):
+        text = value.strip()
+        return (text,) if text else ()
+    if not isinstance(value, list | tuple):
+        raise ValueError("mem0.retrieval.trigger_keywords must be a list of strings")
+
+    keywords: list[str] = []
+    for keyword in value:
+        if not isinstance(keyword, str):
+            raise ValueError("mem0.retrieval.trigger_keywords must contain only strings")
+        text = keyword.strip()
+        if text:
+            keywords.append(text)
+    return tuple(keywords)
+
+
 @dataclass(frozen=True)
 class RetrievalDecision:
     should_search: bool
@@ -39,19 +58,12 @@ class LongTermRetrievalPolicy:
                 f"mem0.retrieval.policy must be one of {sorted(VALID_POLICIES)}, got {policy!r}"
             )
 
-        raw_keywords = retrieval_cfg.get("trigger_keywords") or ()
-        keywords = tuple(
-            str(keyword).strip()
-            for keyword in raw_keywords
-            if isinstance(keyword, str) and keyword.strip()
-        )
-
         return cls(
             enabled=bool(retrieval_cfg.get("enabled", True)),
             policy=policy,
             interval_turns=max(1, int(retrieval_cfg.get("interval_turns", 10))),
             min_query_chars=max(0, int(retrieval_cfg.get("min_query_chars", 0))),
-            trigger_keywords=keywords,
+            trigger_keywords=_parse_trigger_keywords(retrieval_cfg.get("trigger_keywords")),
         )
 
     def decide(
@@ -97,3 +109,6 @@ class LongTermRetrievalPolicy:
         if last_search_round is None:
             return True
         return current_round - last_search_round >= self.interval_turns
+
+
+__all__ = ["LongTermRetrievalPolicy", "RetrievalDecision"]

--- a/src/memory/search_cache.py
+++ b/src/memory/search_cache.py
@@ -1,0 +1,90 @@
+"""Small in-process cache for long-term memory search results."""
+
+from __future__ import annotations
+
+import time
+from collections import OrderedDict
+from collections.abc import Callable
+from copy import deepcopy
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class SearchCacheKey:
+    user_id: str
+    agent_id: str
+    query: str
+    limit: int
+    threshold: float
+
+
+@dataclass
+class _SearchCacheEntry:
+    expires_at: float
+    value: list[dict[str, Any]]
+
+
+class SearchCache:
+    """TTL + LRU cache for repeated mem0.search calls in one process."""
+
+    def __init__(
+        self,
+        *,
+        ttl_seconds: int,
+        max_entries: int,
+        time_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self.ttl_seconds = max(0, int(ttl_seconds))
+        self.max_entries = max(1, int(max_entries))
+        self._time_fn = time_fn
+        self._entries: OrderedDict[SearchCacheKey, _SearchCacheEntry] = OrderedDict()
+
+    @staticmethod
+    def make_key(
+        *,
+        user_id: str,
+        agent_id: str,
+        query: str,
+        limit: int,
+        threshold: float,
+    ) -> SearchCacheKey:
+        return SearchCacheKey(
+            user_id=user_id,
+            agent_id=agent_id,
+            query=" ".join(query.strip().split()),
+            limit=limit,
+            threshold=threshold,
+        )
+
+    def get(self, key: SearchCacheKey) -> list[dict[str, Any]] | None:
+        entry = self._entries.get(key)
+        if entry is None:
+            return None
+        if entry.expires_at <= self._time_fn():
+            self._entries.pop(key, None)
+            return None
+        self._entries.move_to_end(key)
+        return deepcopy(entry.value)
+
+    def set(self, key: SearchCacheKey, value: list[dict[str, Any]]) -> None:
+        if self.ttl_seconds <= 0:
+            return
+        self._entries[key] = _SearchCacheEntry(
+            expires_at=self._time_fn() + self.ttl_seconds,
+            value=deepcopy(value),
+        )
+        self._entries.move_to_end(key)
+        while len(self._entries) > self.max_entries:
+            self._entries.popitem(last=False)
+
+    def invalidate_scope(self, *, user_id: str, agent_id: str) -> None:
+        for key in list(self._entries):
+            if key.user_id == user_id and key.agent_id == agent_id:
+                self._entries.pop(key, None)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+    def __len__(self) -> int:
+        return len(self._entries)

--- a/src/memory/search_cache.py
+++ b/src/memory/search_cache.py
@@ -10,6 +10,10 @@ from dataclasses import dataclass
 from typing import Any
 
 
+def normalize_search_query(query: str) -> str:
+    return " ".join(query.strip().split())
+
+
 @dataclass(frozen=True)
 class SearchCacheKey:
     user_id: str
@@ -52,7 +56,7 @@ class SearchCache:
         return SearchCacheKey(
             user_id=user_id,
             agent_id=agent_id,
-            query=" ".join(query.strip().split()),
+            query=normalize_search_query(query),
             limit=limit,
             threshold=threshold,
         )
@@ -88,3 +92,6 @@ class SearchCache:
 
     def __len__(self) -> int:
         return len(self._entries)
+
+
+__all__ = ["SearchCache", "SearchCacheKey", "normalize_search_query"]

--- a/tests/memory/test-exe.md
+++ b/tests/memory/test-exe.md
@@ -21,6 +21,17 @@ uv run pytest tests/memory/ -v
 
 **期望**：`113 passed`
 
+## 2.1 长期记忆检索策略与缓存
+
+```bash
+uv run pytest tests/memory/test_manager.py tests/memory/test_long_term.py -q
+```
+
+**期望**：
+- `MemoryManager` 缺少 `mem0.retrieval` 时仍保持每轮检索。
+- `hybrid` 策略按关键词或间隔兜底触发，短输入跳过。
+- `LongTermMemory` 使用 `mem0.search.limit/threshold`，重复查询命中进程内缓存，`add()` 成功后清除同 user/agent 缓存。
+
 ## 3. Live 端到端测试（消耗真实 mem0 + LLM tokens）
 
 ### 前置 `.env`

--- a/tests/memory/test_long_term.py
+++ b/tests/memory/test_long_term.py
@@ -340,6 +340,28 @@ async def test_search_cache_reuses_same_query_result() -> None:
 
 
 @pytest.mark.asyncio
+async def test_search_uses_normalized_query_for_backend_and_cache() -> None:
+    with patch("mem0.MemoryClient") as mock_client_cls:
+        mock_backend = MagicMock()
+        mock_backend.search = MagicMock(
+            return_value={"results": [{"memory": "normalized fact", "score": 0.9}]}
+        )
+        mock_client_cls.return_value = mock_backend
+
+        ltm = LongTermMemory(
+            _sdk_config(
+                retrieval={"cache": {"enabled": True, "backend": "memory", "ttl_seconds": 60}}
+            )
+        )
+        first = await ltm.search("  same   query  ", user_id="alice", agent_id="atri")
+        second = await ltm.search("same query", user_id="alice", agent_id="atri")
+
+        assert first == second == [{"memory": "normalized fact", "score": 0.9}]
+        mock_backend.search.assert_called_once()
+        assert mock_backend.search.call_args.args[0] == "same query"
+
+
+@pytest.mark.asyncio
 async def test_add_success_invalidates_search_cache() -> None:
     with patch("mem0.MemoryClient") as mock_client_cls:
         mock_backend = MagicMock()

--- a/tests/memory/test_long_term.py
+++ b/tests/memory/test_long_term.py
@@ -35,6 +35,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from src.memory.long_term import LongTermMemory, _translate_local_deploy
+from src.memory.search_cache import SearchCache
 
 # ---------------------------------------------------------------------------
 # Config fixtures
@@ -42,8 +43,18 @@ from src.memory.long_term import LongTermMemory, _translate_local_deploy
 # ---------------------------------------------------------------------------
 
 
-def _sdk_config(api_key: str = "m0-test-key") -> dict[str, Any]:
-    return {"mode": "sdk", "sdk": {"api_key": api_key}}
+def _sdk_config(
+    api_key: str = "m0-test-key",
+    *,
+    search: dict[str, Any] | None = None,
+    retrieval: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    config: dict[str, Any] = {"mode": "sdk", "sdk": {"api_key": api_key}}
+    if search is not None:
+        config["search"] = search
+    if retrieval is not None:
+        config["retrieval"] = retrieval
+    return config
 
 
 def _local_deploy_config() -> dict[str, Any]:
@@ -254,6 +265,28 @@ async def test_search_respects_limit() -> None:
 
 
 @pytest.mark.asyncio
+async def test_search_uses_configured_default_limit_and_threshold() -> None:
+    """mem0.search defaults come from memory_config.yaml when caller omits them."""
+    with patch("mem0.MemoryClient") as mock_client_cls:
+        mock_backend = MagicMock()
+        mock_backend.search = MagicMock(
+            return_value={
+                "results": [
+                    {"memory": "strong", "score": 0.8},
+                    {"memory": "weak", "score": 0.4},
+                ]
+            }
+        )
+        mock_client_cls.return_value = mock_backend
+
+        ltm = LongTermMemory(_sdk_config(search={"limit": 1, "threshold": 0.5}))
+        results = await ltm.search("q", user_id="a", agent_id="b")
+
+        assert mock_backend.search.call_args.kwargs["top_k"] == 1
+        assert results == [{"memory": "strong", "score": 0.8}]
+
+
+@pytest.mark.asyncio
 async def test_search_returns_empty_on_backend_error() -> None:
     """A broken mem0 must degrade gracefully -- we don't crash the chat turn.
 
@@ -283,6 +316,74 @@ async def test_add_swallows_backend_errors() -> None:
         # Must not raise -- caller's on_round_complete keeps going.
         # 不得抛异常——调用方的 on_round_complete 可以继续执行。
         await ltm.add([], user_id="a", agent_id="b", run_id="c")
+
+
+@pytest.mark.asyncio
+async def test_search_cache_reuses_same_query_result() -> None:
+    with patch("mem0.MemoryClient") as mock_client_cls:
+        mock_backend = MagicMock()
+        mock_backend.search = MagicMock(
+            return_value={"results": [{"memory": "cached fact", "score": 0.9}]}
+        )
+        mock_client_cls.return_value = mock_backend
+
+        ltm = LongTermMemory(
+            _sdk_config(
+                retrieval={"cache": {"enabled": True, "backend": "memory", "ttl_seconds": 60}}
+            )
+        )
+        first = await ltm.search("  same   query  ", user_id="alice", agent_id="atri")
+        second = await ltm.search("same query", user_id="alice", agent_id="atri")
+
+        assert first == second == [{"memory": "cached fact", "score": 0.9}]
+        assert mock_backend.search.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_add_success_invalidates_search_cache() -> None:
+    with patch("mem0.MemoryClient") as mock_client_cls:
+        mock_backend = MagicMock()
+        mock_backend.search = MagicMock(
+            side_effect=[
+                {"results": [{"memory": "old fact", "score": 0.9}]},
+                {"results": [{"memory": "new fact", "score": 0.9}]},
+            ]
+        )
+        mock_backend.add = MagicMock(return_value={"results": []})
+        mock_client_cls.return_value = mock_backend
+
+        ltm = LongTermMemory(
+            _sdk_config(
+                retrieval={"cache": {"enabled": True, "backend": "memory", "ttl_seconds": 60}}
+            )
+        )
+        assert await ltm.search("q", user_id="alice", agent_id="atri") == [
+            {"memory": "old fact", "score": 0.9}
+        ]
+        await ltm.add([{"role": "human", "content": "new"}], "alice", "atri", "sess")
+        assert await ltm.search("q", user_id="alice", agent_id="atri") == [
+            {"memory": "new fact", "score": 0.9}
+        ]
+        assert mock_backend.search.call_count == 2
+
+
+def test_search_cache_expires_and_evicts_oldest() -> None:
+    now = 100.0
+
+    def _time() -> float:
+        return now
+
+    cache = SearchCache(ttl_seconds=10, max_entries=1, time_fn=_time)
+    key_a = SearchCache.make_key(user_id="u", agent_id="a", query="first", limit=5, threshold=0.3)
+    key_b = SearchCache.make_key(user_id="u", agent_id="a", query="second", limit=5, threshold=0.3)
+
+    cache.set(key_a, [{"memory": "A"}])
+    cache.set(key_b, [{"memory": "B"}])
+    assert cache.get(key_a) is None
+    assert cache.get(key_b) == [{"memory": "B"}]
+
+    now = 111.0
+    assert cache.get(key_b) is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/memory/test_manager.py
+++ b/tests/memory/test_manager.py
@@ -72,6 +72,12 @@ def _default_config() -> dict[str, Any]:
     }
 
 
+def _config_with_retrieval(retrieval: dict[str, Any]) -> dict[str, Any]:
+    config = _default_config()
+    config["mem0"] = {"search": {"limit": 5, "threshold": 0.3}, "retrieval": retrieval}
+    return config
+
+
 def _make_llm(response: str = "mock summary") -> MagicMock:
     llm = MagicMock()
     llm.chat_completion = AsyncMock(return_value=response)
@@ -368,6 +374,93 @@ async def test_search_long_term_delegates_to_injected_backend(tmp_path: Path) ->
     results = await mgr.search_long_term("hello", limit=3)
     long_term.search.assert_awaited_once_with("hello", user_id="alice", agent_id="atri", limit=3)
     assert results == [{"memory": "fact1", "score": 0.9}]
+
+
+@pytest.mark.asyncio
+async def test_search_long_term_without_retrieval_config_preserves_always_policy(
+    tmp_path: Path,
+) -> None:
+    long_term = MagicMock()
+    long_term.search = AsyncMock(return_value=[])
+    mgr = MemoryManager(
+        _default_config(),
+        _make_factory(),
+        character="atri",
+        user_id="alice",
+        character_dir=tmp_path,
+        long_term=long_term,
+    )
+
+    await mgr.search_long_term("one")
+    await mgr.search_long_term("two")
+
+    assert long_term.search.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_search_long_term_hybrid_skips_until_interval_or_trigger(
+    tmp_path: Path,
+) -> None:
+    long_term = MagicMock()
+    long_term.search = AsyncMock(return_value=[])
+    mgr = MemoryManager(
+        _config_with_retrieval(
+            {
+                "policy": "hybrid",
+                "interval_turns": 10,
+                "min_query_chars": 6,
+                "trigger_keywords": ["还记得", "之前", "我说过"],
+            }
+        ),
+        _make_factory(),
+        character="atri",
+        user_id="alice",
+        character_dir=tmp_path,
+        long_term=long_term,
+    )
+
+    assert await mgr.search_long_term("今天天气不错") == []
+    assert long_term.search.await_count == 1
+
+    mgr.state["total_rounds"] = 5
+    assert await mgr.search_long_term("继续聊一下") == []
+    assert long_term.search.await_count == 1
+
+    assert await mgr.search_long_term("你还记得我的偏好吗") == []
+    assert long_term.search.await_count == 2
+
+    mgr.state["total_rounds"] = 14
+    assert await mgr.search_long_term("普通话题继续") == []
+    assert long_term.search.await_count == 2
+
+    mgr.state["total_rounds"] = 15
+    assert await mgr.search_long_term("普通话题继续") == []
+    assert long_term.search.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_search_long_term_short_query_skips_even_when_triggered(
+    tmp_path: Path,
+) -> None:
+    long_term = MagicMock()
+    long_term.search = AsyncMock(return_value=[])
+    mgr = MemoryManager(
+        _config_with_retrieval(
+            {
+                "policy": "triggered",
+                "min_query_chars": 6,
+                "trigger_keywords": ["记得"],
+            }
+        ),
+        _make_factory(),
+        character="atri",
+        user_id="alice",
+        character_dir=tmp_path,
+        long_term=long_term,
+    )
+
+    assert await mgr.search_long_term("记得") == []
+    long_term.search.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/memory/test_manager.py
+++ b/tests/memory/test_manager.py
@@ -562,6 +562,52 @@ async def test_search_long_term_short_query_skips_even_when_triggered(
     long_term.search.assert_not_awaited()
 
 
+def test_retrieval_trigger_keywords_string_is_single_keyword(tmp_path: Path) -> None:
+    mgr = MemoryManager(
+        _config_with_retrieval(
+            {
+                "policy": "triggered",
+                "min_query_chars": 1,
+                "trigger_keywords": "记得",
+            }
+        ),
+        _make_factory(),
+        character="atri",
+        user_id="alice",
+        character_dir=tmp_path,
+    )
+
+    assert mgr.long_term_retrieval_policy.trigger_keywords == ("记得",)
+    assert (
+        mgr.long_term_retrieval_policy.decide(
+            "我", current_round=0, last_search_round=None
+        ).should_search
+        is False
+    )
+    assert (
+        mgr.long_term_retrieval_policy.decide(
+            "你还记得吗", current_round=0, last_search_round=None
+        ).should_search
+        is True
+    )
+
+
+def test_retrieval_trigger_keywords_rejects_non_string_items(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="trigger_keywords"):
+        MemoryManager(
+            _config_with_retrieval(
+                {
+                    "policy": "triggered",
+                    "trigger_keywords": ["记得", 123],
+                }
+            ),
+            _make_factory(),
+            character="atri",
+            user_id="alice",
+            character_dir=tmp_path,
+        )
+
+
 @pytest.mark.asyncio
 async def test_search_long_term_returns_empty_when_no_backend(tmp_path: Path) -> None:
     # 未注入 long_term


### PR DESCRIPTION
## Summary
- add configurable long-term memory retrieval policies: always, interval, triggered, hybrid
- add process-local TTL cache for mem0 search results with invalidation after successful add
- document the new memory retrieval config and test instructions
- fix session cookie samesite typing for mypy

## Tests
- uv run ruff check . --fix
- uv run python -m mypy src/ --ignore-missing-imports
- uv run pytest tests/memory/test_manager.py tests/memory/test_long_term.py tests/routes/test_auth.py -q