### PR TITLE
feat: scope short memory by chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ data/avatars/
 .claude/
 
 prompts/persona/
+*.chat_scope_migrated
+*.legacy_migrated

--- a/config/llm_config.yaml
+++ b/config/llm_config.yaml
@@ -39,7 +39,7 @@ llm_configs:
         temperature: 0.8                   # 采样温度(DS默认0-1)
 
       siliconflow:
-        model: deepseek-ai/DeepSeek-V4-Flash    # 模型名称
+        model: deepseek-ai/DeepSeek-V3.2    # 模型名称
         base_url: https://api.siliconflow.cn/v1 # API 基础 URL
         api_key: ${SILICONFLOW_API_KEY}         # API 密钥（从环境变量读取）
         temperature: 0.8     
@@ -62,7 +62,7 @@ llm_configs:
         temperature: 0.3                   # 采样温度：压缩场景使用较低值以确保稳定性
 
       siliconflow:
-        model: deepseek-ai/DeepSeek-V4-Flash         # 使用更轻量/更便宜的模型以降低压缩成本
+        model: deepseek-ai/DeepSeek-V3.2         # 使用更轻量/更便宜的模型以降低压缩成本
         base_url: https://api.siliconflow.cn/v1    # API 基础 URL（从环境变量读取）
         api_key: ${COMPRESS_API_KEY}       # API 密钥（从环境变量读取）
         temperature: 0.3                   # 采样温度：压缩场景使用较低值以确保稳定性

--- a/config/memory_config.yaml
+++ b/config/memory_config.yaml
@@ -14,9 +14,9 @@ short_term:
 
   # L3 Collapse -- round-driven compression
   collapse:
-    trigger_rounds: 26               # every N rounds triggers L3
+    trigger_rounds: 20               # compatibility: raw tail trigger uses keep_recent + compress
     compress_rounds: 20              # oldest M rounds get compressed
-    keep_recent_rounds: 6            # keep latest K rounds raw
+    keep_recent_rounds: 20           # keep latest K rounds raw
 
   # L4 Super-Compact -- block-count-driven meta compression
   super_compact:

--- a/config/memory_config.yaml
+++ b/config/memory_config.yaml
@@ -14,7 +14,7 @@ short_term:
 
   # L3 Collapse -- round-driven compression
   collapse:
-    trigger_rounds: 20               # compatibility: raw tail trigger uses keep_recent + compress
+    trigger_rounds: 20               # deprecated compatibility field; no trigger logic reads it
     compress_rounds: 20              # oldest M rounds get compressed
     keep_recent_rounds: 20           # keep latest K rounds raw
 
@@ -131,7 +131,7 @@ mem0:
       - 我的信息
     cache:
       enabled: true
-      backend: memory               #进程本地缓存，无外部服务
+      backend: memory               # 进程本地缓存，无外部服务
       ttl_seconds: 1800
       max_entries: 512
 

--- a/config/memory_config.yaml
+++ b/config/memory_config.yaml
@@ -114,13 +114,13 @@ mem0:
     threshold: 0.3
     rerank: false
 
-  # Long-term retrieval policy. Missing this block keeps legacy behavior
+  # 长期检索政策。缺少此块会保留遗留行为
   # (search every turn); this default saves mem0 retrieval quota.
   retrieval:
     enabled: true
     policy: hybrid                  # always | interval | triggered | hybrid
-    interval_turns: 10              # fallback search after N valid rounds
-    min_query_chars: 6              # skip very short inputs
+    interval_turns: 10              # N 个有效轮次后的回退搜索
+    min_query_chars: 6              # 跳过非常短的输入
     trigger_keywords:
       - 记得
       - 还记得
@@ -131,7 +131,7 @@ mem0:
       - 我的信息
     cache:
       enabled: true
-      backend: memory               # process-local cache, no external service
+      backend: memory               #进程本地缓存，无外部服务
       ttl_seconds: 1800
       max_entries: 512
 

--- a/src/main.py
+++ b/src/main.py
@@ -10,7 +10,7 @@ Startup sequence:
 2. ``load_config()`` on ``config.yaml``
 3. Resolve LLM roles (chat / l3_compress / l4_compact / title_gen) for logging
 4. Construct :class:`ServiceContext` (holds config, empty agent cache)
-5. ``ctx.get_or_create_agent("atri", user_id="main_demo")`` to build one
+5. ``ctx.get_or_create_agent("atri", user_id="main_demo", chat_id="main_demo")`` to build one
    ChatAgent end-to-end (Persona + LongTermMemory + MemoryManager + LLM)
 6. Log ``ChatAgent ready | character=atri | persona={name} | long_term={on|off}``
 7. Create FastAPI app via ``create_app(config)``
@@ -52,6 +52,7 @@ _DEFAULT_ENV = _REPO_ROOT / ".env"
 _LLM_ROLES = ("chat", "l3_compress", "l4_compact", "title_gen")
 _DEMO_CHARACTER = "atri"
 _DEMO_USER_ID = "main_demo"
+_DEMO_CHAT_ID = "main_demo"
 
 
 def main() -> None:
@@ -96,7 +97,11 @@ def main() -> None:
         ctx = None
         try:
             ctx = ServiceContext(config)
-            agent = ctx.get_or_create_agent(_DEMO_CHARACTER, user_id=_DEMO_USER_ID)
+            agent = ctx.get_or_create_agent(
+                _DEMO_CHARACTER,
+                user_id=_DEMO_USER_ID,
+                chat_id=_DEMO_CHAT_ID,
+            )
         except Exception as exc:  # noqa: BLE001
             logger.error("ServiceContext / ChatAgent construction failed | error={!r}", exc)
             if ctx:

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -7,8 +7,8 @@ Responsibilities (Phase 3 Step 5 + Step 6 scope, per US-MEM-005/006):
   error rounds so the frontend can render them).
 * Track ``total_rounds`` and maintain ``recent_messages`` -- valid rounds
   only, per §3.2 round definition.
-* Trigger L3 Collapse every ``trigger_rounds`` (compress the oldest
-  ``compress_rounds`` rounds in ``recent_messages``). When a
+* Trigger L3 Collapse when ``recent_messages`` holds enough raw rounds to
+  both compress ``compress_rounds`` and still keep ``keep_recent_rounds``. When a
   :class:`LongTermMemory` is injected, the same raw window is persisted to
   mem0 via ``long_term.add`` (best-effort; errors log WARNING but never
   break the round).
@@ -31,8 +31,8 @@ Memory Manager——按轮次编排短期记忆。
   以便前端渲染）。
 * 跟踪 ``total_rounds`` 并维护 ``recent_messages``——仅统计有效轮次，
   轮次定义参见 §3.2。
-* 每 ``trigger_rounds`` 触发一次 L3 Collapse（压缩 ``recent_messages``
-  中最早的 ``compress_rounds`` 轮）。当注入了 :class:`LongTermMemory`
+* 当 ``recent_messages`` 中原始轮次足够同时压缩 ``compress_rounds`` 并保留
+  ``keep_recent_rounds`` 时触发 L3 Collapse。当注入了 :class:`LongTermMemory`
   时，同一原始窗口会通过 ``long_term.add`` 持久化到 mem0（尽力而为；
   失败仅记录 WARNING，绝不中断当前轮次）。
 * 当 ``len(active_blocks) >= trigger_blocks`` 时触发 L4 Super-Compact。
@@ -312,7 +312,7 @@ class MemoryManager:
       1. L1 snip the user message.
       2. Append both turns to chat_history (regardless of round validity).
       3. Update ``recent_messages`` + ``total_rounds`` (valid rounds only).
-      4. Trigger L3 Collapse when ``total_rounds % trigger_rounds == 0``.
+      4. Trigger L3 Collapse once the raw tail can keep K rounds and compress M rounds.
       5. Trigger L4 Super-Compact when ``len(active_blocks) >= trigger_blocks``.
       6. Persist via :class:`ShortTermStore` once per round.
 
@@ -326,7 +326,7 @@ class MemoryManager:
       1. 对用户消息执行 L1 snip。
       2. 将双方消息追加到 chat_history（无论轮次是否有效）。
       3. 更新 ``recent_messages`` + ``total_rounds``（仅统计有效轮次）。
-      4. 当 ``total_rounds % trigger_rounds == 0`` 时触发 L3 Collapse。
+      4. 当原始尾部足够保留 K 轮并压缩 M 轮时触发 L3 Collapse。
       5. 当 ``len(active_blocks) >= trigger_blocks`` 时触发 L4 Super-Compact。
       6. 每轮通过 :class:`ShortTermStore` 持久化一次。
 
@@ -674,11 +674,7 @@ class MemoryManager:
             state["recent_messages"].append({"role": "ai", "content": ai_msg.get("content", "")})
             state["total_rounds"] = int(state.get("total_rounds", 0)) + 1
 
-            total = int(state["total_rounds"])
-            if total > 0 and total % self.trigger_rounds == 0:
-                await self._trigger_l3()
-            if len(state["active_blocks"]) >= self.trigger_blocks:
-                await self._trigger_l4()
+            await self._maybe_trigger_l3()
 
         self.short_term_store.save(state)
         # Catch-up only replays already-persisted chat_history; no new data
@@ -723,11 +719,7 @@ class MemoryManager:
             state["recent_messages"].append({"role": "ai", "content": ai_msg.get("content", "")})
             state["total_rounds"] = int(state.get("total_rounds", 0)) + 1
 
-            total = int(state["total_rounds"])
-            if total > 0 and total % self.trigger_rounds == 0:
-                await self._trigger_l3()
-            if len(state["active_blocks"]) >= self.trigger_blocks:
-                await self._trigger_l4()
+            await self._maybe_trigger_l3()
 
         self.short_term_store.save(state)
         self._dirty = False
@@ -813,12 +805,7 @@ class MemoryManager:
             self._state["total_rounds"] = int(self._state.get("total_rounds", 0)) + 1
             self._dirty = True
 
-        total_rounds: int = int(self._state["total_rounds"])
-        if total_rounds > 0 and total_rounds % self.trigger_rounds == 0:
-            await self._trigger_l3()
-
-        if len(self._state["active_blocks"]) >= self.trigger_blocks:
-            await self._trigger_l4()
+        await self._maybe_trigger_l3()
 
         self.short_term_store.save(self._state)
 
@@ -873,6 +860,16 @@ class MemoryManager:
             if end > max_end:
                 max_end = end
         return max_end + 1
+
+    async def _maybe_trigger_l3(self) -> None:
+        assert self._state is not None
+        recent: list[dict[str, Any]] = self._state["recent_messages"]
+        required_rounds = self.keep_recent_rounds + self.compress_rounds
+        required_messages = required_rounds * 2
+        while len(recent) >= required_messages:
+            await self._trigger_l3()
+            if len(self._state["active_blocks"]) >= self.trigger_blocks:
+                await self._trigger_l4()
 
     async def _trigger_l3(self) -> None:
         assert self._state is not None

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -70,6 +70,7 @@ LLMFactoryFn = Callable[[str], LLMInterface]
 _SHORT_TERM_FILENAME = "short_term_memory.json"
 _SESSIONS_SUBDIR = "sessions"
 _LEGACY_MIGRATION_MARKER = ".legacy_migrated"
+_CHAT_SCOPE_MIGRATION_MARKER = ".chat_scope_migrated"
 
 
 def _new_session_id() -> str:
@@ -149,6 +150,69 @@ def _migrate_legacy_character_memory(legacy_dir: Path, target_dir: Path) -> None
             "Legacy character memory copied | legacy={} | target={} | items={}",
             legacy_dir,
             target_dir,
+            ",".join(migrated_items),
+        )
+
+
+def resolve_user_character_chat_dir(
+    memory_config: dict[str, Any],
+    user_id: str,
+    character: str,
+    chat_id: str,
+    *,
+    migrate_legacy: bool = True,
+) -> Path:
+    """Return the chat-scoped local memory directory for a character chat."""
+
+    character_dir = resolve_user_character_dir(
+        memory_config,
+        user_id,
+        character,
+        migrate_legacy=migrate_legacy,
+    )
+    chat_dir = character_dir / "chats" / chat_id
+    if migrate_legacy:
+        _migrate_character_scope_memory_to_chat(character_dir, chat_dir)
+    return chat_dir
+
+
+def _migrate_character_scope_memory_to_chat(character_dir: Path, chat_dir: Path) -> None:
+    if not character_dir.is_dir():
+        return
+
+    marker_path = character_dir / _CHAT_SCOPE_MIGRATION_MARKER
+    if marker_path.exists():
+        return
+
+    source_short_term = character_dir / _SHORT_TERM_FILENAME
+    source_sessions = character_dir / _SESSIONS_SUBDIR
+    target_short_term = chat_dir / _SHORT_TERM_FILENAME
+    target_sessions = chat_dir / _SESSIONS_SUBDIR
+    migrated_items: list[str] = []
+    handled_legacy = False
+
+    if source_short_term.is_file():
+        if not target_short_term.exists():
+            chat_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_short_term, target_short_term)
+            migrated_items.append(_SHORT_TERM_FILENAME)
+        handled_legacy = target_short_term.exists()
+
+    if source_sessions.is_dir():
+        if not target_sessions.exists():
+            chat_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copytree(source_sessions, target_sessions)
+            migrated_items.append(_SESSIONS_SUBDIR)
+        handled_legacy = handled_legacy or target_sessions.exists()
+
+    if handled_legacy:
+        marker_path.touch(exist_ok=True)
+
+    if migrated_items:
+        logger.info(
+            "Character-scoped memory copied to chat scope | legacy={} | target={} | items={}",
+            character_dir,
+            chat_dir,
             ",".join(migrated_items),
         )
 
@@ -277,6 +341,7 @@ class MemoryManager:
         llm_factory_fn: LLMFactoryFn,
         character: str,
         user_id: str,
+        chat_id: str | None = None,
         character_dir: Path | None = None,
         long_term: LongTermMemory | None = None,
     ) -> None:
@@ -284,6 +349,7 @@ class MemoryManager:
         self.llm_factory_fn = llm_factory_fn
         self.character = character
         self.user_id = user_id
+        self.chat_id = chat_id
         self.long_term = long_term
 
         short_term_cfg = memory_config.get("short_term", {})
@@ -308,7 +374,15 @@ class MemoryManager:
         self._last_long_term_search_round: int | None = None
 
         if character_dir is None:
-            character_dir = resolve_user_character_dir(memory_config, user_id, character)
+            if chat_id is None:
+                character_dir = resolve_user_character_dir(memory_config, user_id, character)
+            else:
+                character_dir = resolve_user_character_chat_dir(
+                    memory_config,
+                    user_id,
+                    character,
+                    chat_id,
+                )
         self.character_dir = Path(character_dir)
 
         self._active_session_id: str | None = None
@@ -412,9 +486,10 @@ class MemoryManager:
         self._state = ShortTermStore.get_skeleton(session_id, self.character)
         self._dirty = False
         logger.info(
-            "MemoryManager short-term state reset | character={} | user_id={} | session_id={}",
+            "MemoryManager short-term state reset | character={} | user_id={} | chat_id={} | session_id={}",
             self.character,
             self.user_id,
+            self.chat_id,
             session_id,
         )
 
@@ -993,4 +1068,10 @@ class MemoryManager:
         return messages
 
 
-__all__ = ["MemoryManager", "LLMFactoryFn"]
+__all__ = [
+    "MemoryManager",
+    "LLMFactoryFn",
+    "legacy_character_dir",
+    "resolve_user_character_chat_dir",
+    "resolve_user_character_dir",
+]

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -53,7 +53,7 @@ import shutil
 from collections.abc import Callable
 from datetime import UTC, datetime
 from html import escape
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Any
 
 from loguru import logger
@@ -71,6 +71,23 @@ _SHORT_TERM_FILENAME = "short_term_memory.json"
 _SESSIONS_SUBDIR = "sessions"
 _LEGACY_MIGRATION_MARKER = ".legacy_migrated"
 _CHAT_SCOPE_MIGRATION_MARKER = ".chat_scope_migrated"
+
+
+def _validate_path_component(label: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    clean = value.strip()
+    path = PurePath(clean)
+    if (
+        not clean
+        or clean in {".", ".."}
+        or path.is_absolute()
+        or len(path.parts) != 1
+        or "/" in clean
+        or "\\" in clean
+    ):
+        raise ValueError(f"Invalid {label}: {value!r}")
+    return clean
 
 
 def _new_session_id() -> str:
@@ -99,18 +116,21 @@ def resolve_user_character_dir(
     fallback backup.
     """
 
+    safe_user_id = _validate_path_component("user_id", user_id)
+    safe_character = _validate_path_component("character", character)
     chars_root = Path(memory_config.get("storage", {}).get("characters_dir", "./data/characters"))
-    character_dir = chars_root / user_id / character
+    character_dir = chars_root / safe_user_id / safe_character
     if migrate_legacy:
-        _migrate_legacy_character_memory(chars_root / character, character_dir)
+        _migrate_legacy_character_memory(chars_root / safe_character, character_dir)
     return character_dir
 
 
 def legacy_character_dir(memory_config: dict[str, Any], character: str) -> Path:
     """Return the pre-user-scope memory directory for ``character``."""
 
+    safe_character = _validate_path_component("character", character)
     chars_root = Path(memory_config.get("storage", {}).get("characters_dir", "./data/characters"))
-    return chars_root / character
+    return chars_root / safe_character
 
 
 def _migrate_legacy_character_memory(legacy_dir: Path, target_dir: Path) -> None:
@@ -164,13 +184,14 @@ def resolve_user_character_chat_dir(
 ) -> Path:
     """Return the chat-scoped local memory directory for a character chat."""
 
+    safe_chat_id = _validate_path_component("chat_id", chat_id)
     character_dir = resolve_user_character_dir(
         memory_config,
         user_id,
         character,
         migrate_legacy=migrate_legacy,
     )
-    chat_dir = character_dir / "chats" / chat_id
+    chat_dir = character_dir / "chats" / safe_chat_id
     if migrate_legacy:
         _migrate_character_scope_memory_to_chat(character_dir, chat_dir)
     return chat_dir

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -486,7 +486,8 @@ class MemoryManager:
         self._state = ShortTermStore.get_skeleton(session_id, self.character)
         self._dirty = False
         logger.info(
-            "MemoryManager short-term state reset | character={} | user_id={} | chat_id={} | session_id={}",
+            "MemoryManager short-term state reset | character={} | user_id={} | "
+            "chat_id={} | session_id={}",
             self.character,
             self.user_id,
             self.chat_id,

--- a/src/routes/chat_ws.py
+++ b/src/routes/chat_ws.py
@@ -160,10 +160,10 @@ async def _handle_text_input(
 
     logger.info(f"Received text input | chat_id={chat_id} | character_id={character_id}")
 
-    # Get or create ChatAgent for this character/user
-    # 获取或创建此 character/user 的 ChatAgent
+    # Get or create ChatAgent for this character/user/chat.
+    # 获取或创建此 character/user/chat 的 ChatAgent。
     try:
-        agent = service_context.get_or_create_agent(character_id, user_id)
+        agent = service_context.get_or_create_agent(character_id, user_id, chat_id)
     except Exception as e:
         logger.error(f"Failed to get ChatAgent: {e}")
         await _send_error(

--- a/src/routes/chat_ws.py
+++ b/src/routes/chat_ws.py
@@ -160,6 +160,21 @@ async def _handle_text_input(
 
     logger.info(f"Received text input | chat_id={chat_id} | character_id={character_id}")
 
+    chat = await storage.get_chat_for_user(user_id, chat_id)
+    if chat is None or chat.get("character_id") != character_id:
+        logger.warning(
+            "Rejected chat input for mismatched chat | user_id={} | chat_id={} | character_id={}",
+            user_id,
+            chat_id,
+            character_id,
+        )
+        await _send_error(
+            websocket,
+            f"Chat '{chat_id}' not found for character '{character_id}'",
+            chat_id=chat_id,
+        )
+        return
+
     # Get or create ChatAgent for this character/user/chat.
     # 获取或创建此 character/user/chat 的 ChatAgent。
     try:

--- a/src/routes/chat_ws.py
+++ b/src/routes/chat_ws.py
@@ -160,7 +160,19 @@ async def _handle_text_input(
 
     logger.info(f"Received text input | chat_id={chat_id} | character_id={character_id}")
 
-    chat = await storage.get_chat_for_user(user_id, chat_id)
+    try:
+        chat = await storage.get_chat_for_user_character(user_id, character_id, chat_id)
+    except ValueError as exc:
+        logger.warning(
+            "Rejected invalid chat input | user_id={} | chat_id={} | character_id={} | error={!r}",
+            user_id,
+            chat_id,
+            character_id,
+            exc,
+        )
+        await _send_error(websocket, f"Invalid chat request: {exc}", chat_id=chat_id)
+        return
+
     if chat is None or chat.get("character_id") != character_id:
         logger.warning(
             "Rejected chat input for mismatched chat | user_id={} | chat_id={} | character_id={}",

--- a/src/routes/data.py
+++ b/src/routes/data.py
@@ -49,7 +49,12 @@ async def _unlink_if_exists(path: Path) -> bool:
     return await asyncio.to_thread(_delete)
 
 
-async def _ensure_user_chat(request: Request, user_id: str, character_id: str, chat_id: str) -> dict:
+async def _ensure_user_chat(
+    request: Request,
+    user_id: str,
+    character_id: str,
+    chat_id: str,
+) -> dict:
     storage = request.app.state.storage
     chat = await storage.get_chat_for_user(user_id, chat_id)
     if chat is None or chat.get("character_id") != character_id:
@@ -104,7 +109,8 @@ async def clear_short_term_memory(
     )
 
     logger.info(
-        "Short-term memory cleared | character={} | user_id={} | chat_id={} | removed={} | cache_reset={}",
+        "Short-term memory cleared | character={} | user_id={} | chat_id={} | "
+        "removed={} | cache_reset={}",
         character_id,
         user_id,
         chat_id,

--- a/src/routes/data.py
+++ b/src/routes/data.py
@@ -56,7 +56,13 @@ async def _ensure_user_chat(
     chat_id: str,
 ) -> dict:
     storage = request.app.state.storage
-    chat = await storage.get_chat_for_user(user_id, chat_id)
+    try:
+        chat = await storage.get_chat_for_user_character(user_id, character_id, chat_id)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
     if chat is None or chat.get("character_id") != character_id:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -95,18 +101,25 @@ async def clear_short_term_memory(
     user_id = get_request_user_id(request)
     await _ensure_user_chat(request, user_id, character_id, chat_id)
     context = _service_context(request)
-    chat_dir = Path(context.get_character_chat_memory_dir(character_id, user_id, chat_id))
-    short_term_path = chat_dir / _SHORT_TERM_FILENAME
-    tmp_path = short_term_path.with_suffix(".json.tmp")
+    try:
+        chat_dir = Path(context.get_character_chat_memory_dir(character_id, user_id, chat_id))
+        short_term_path = chat_dir / _SHORT_TERM_FILENAME
+        tmp_path = short_term_path.with_suffix(".json.tmp")
+        legacy_path = (
+            Path(context.get_legacy_character_memory_dir(character_id)) / _SHORT_TERM_FILENAME
+        )
+        character_scoped_path = (
+            Path(context.get_character_memory_dir(character_id, user_id)) / _SHORT_TERM_FILENAME
+        )
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
 
     removed_short_term = await _unlink_if_exists(short_term_path)
     removed_tmp = await _unlink_if_exists(tmp_path)
     cache_reset = context.reset_short_term_memory(character_id, user_id, chat_id)
-
-    legacy_path = Path(context.get_legacy_character_memory_dir(character_id)) / _SHORT_TERM_FILENAME
-    character_scoped_path = (
-        Path(context.get_character_memory_dir(character_id, user_id)) / _SHORT_TERM_FILENAME
-    )
 
     logger.info(
         "Short-term memory cleared | character={} | user_id={} | chat_id={} | "

--- a/src/routes/data.py
+++ b/src/routes/data.py
@@ -24,6 +24,7 @@ class DataCleanupResponse(BaseModel):
 
     character_id: str
     user_id: str
+    chat_id: str | None = None
     target: str
     status: str
     message: str
@@ -48,6 +49,17 @@ async def _unlink_if_exists(path: Path) -> bool:
     return await asyncio.to_thread(_delete)
 
 
+async def _ensure_user_chat(request: Request, user_id: str, character_id: str, chat_id: str) -> dict:
+    storage = request.app.state.storage
+    chat = await storage.get_chat_for_user(user_id, chat_id)
+    if chat is None or chat.get("character_id") != character_id:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Chat '{chat_id}' not found for character '{character_id}'",
+        )
+    return chat
+
+
 def _get_long_term_memory(request: Request, character_id: str, user_id: str) -> LongTermMemory:
     context = _service_context(request)
     cached = context.get_cached_long_term_memory(character_id, user_id)
@@ -65,31 +77,37 @@ def _get_long_term_memory(request: Request, character_id: str, user_id: str) -> 
 
 
 @router.delete(
-    "/characters/{character_id}/short-term-memory",
+    "/characters/{character_id}/chats/{chat_id}/short-term-memory",
     response_model=DataCleanupResponse,
 )
 async def clear_short_term_memory(
     character_id: str,
+    chat_id: str,
     request: Request,
 ) -> DataCleanupResponse:
-    """Clear short-term memory for current user and character, hot if cached."""
+    """Clear short-term memory for current user, character, and chat."""
 
     user_id = get_request_user_id(request)
+    await _ensure_user_chat(request, user_id, character_id, chat_id)
     context = _service_context(request)
-    character_dir = Path(context.get_character_memory_dir(character_id, user_id))
-    short_term_path = character_dir / _SHORT_TERM_FILENAME
+    chat_dir = Path(context.get_character_chat_memory_dir(character_id, user_id, chat_id))
+    short_term_path = chat_dir / _SHORT_TERM_FILENAME
     tmp_path = short_term_path.with_suffix(".json.tmp")
 
     removed_short_term = await _unlink_if_exists(short_term_path)
     removed_tmp = await _unlink_if_exists(tmp_path)
-    cache_reset = context.reset_short_term_memory(character_id, user_id)
+    cache_reset = context.reset_short_term_memory(character_id, user_id, chat_id)
 
     legacy_path = Path(context.get_legacy_character_memory_dir(character_id)) / _SHORT_TERM_FILENAME
+    character_scoped_path = (
+        Path(context.get_character_memory_dir(character_id, user_id)) / _SHORT_TERM_FILENAME
+    )
 
     logger.info(
-        "Short-term memory cleared | character={} | user_id={} | removed={} | cache_reset={}",
+        "Short-term memory cleared | character={} | user_id={} | chat_id={} | removed={} | cache_reset={}",
         character_id,
         user_id,
+        chat_id,
         removed_short_term,
         cache_reset,
     )
@@ -97,11 +115,13 @@ async def clear_short_term_memory(
     return DataCleanupResponse(
         character_id=character_id,
         user_id=user_id,
+        chat_id=chat_id,
         target="short_term_memory",
         status="cleared",
         message="短期记忆已清理，并已同步当前运行中的记忆状态。",
         details={
             "path": str(short_term_path),
+            "character_scoped_path": str(character_scoped_path),
             "legacy_path": str(legacy_path),
             "removed_file": removed_short_term,
             "removed_tmp": removed_tmp,

--- a/src/service_context.py
+++ b/src/service_context.py
@@ -118,7 +118,7 @@ class ServiceContext:
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
         self._agents: dict[tuple[str, str, str], ChatAgent] = {}
-        self._long_term_memories: dict[tuple[str, str], LongTermMemory | None] = {}
+        self._long_term_memories: dict[tuple[str, str], LongTermMemory] = {}
 
     def get_or_create_agent(self, character_id: str, user_id: str, chat_id: str) -> ChatAgent:
         """Return the cached agent for ``(character_id, user_id, chat_id)`` or build one.
@@ -190,11 +190,16 @@ class ServiceContext:
         """Return the shared long-term memory handle for ``(character_id, user_id)``."""
 
         key = (character_id, user_id)
-        if key not in self._long_term_memories:
-            memory_config = self.config.get("memory", {})
-            mem0_config = memory_config.get("mem0", {})
-            self._long_term_memories[key] = _safe_build_long_term(mem0_config)
-        return self._long_term_memories[key]
+        cached = self._long_term_memories.get(key)
+        if cached is not None:
+            return cached
+
+        memory_config = self.config.get("memory", {})
+        mem0_config = memory_config.get("mem0", {})
+        long_term = _safe_build_long_term(mem0_config)
+        if long_term is not None:
+            self._long_term_memories[key] = long_term
+        return long_term
 
     def get_character_memory_dir(self, character_id: str, user_id: str) -> str:
         """Return and migrate the user-scoped local memory directory path."""
@@ -268,8 +273,6 @@ class ServiceContext:
                     exc,
                 )
         for memory_key, long_term in self._long_term_memories.items():
-            if long_term is None:
-                continue
             try:
                 long_term.close()
             except Exception as exc:  # noqa: BLE001

--- a/src/service_context.py
+++ b/src/service_context.py
@@ -2,16 +2,17 @@
 
 One ServiceContext per process. It holds the merged config (from
 :func:`src.utils.config_loader.load_config`) and lazily constructs one
-:class:`src.agent.chat_agent.ChatAgent` per ``(character_id, user_id)``
-pair, caching each instance so subsequent requests reuse the same memory
-state. Phase 5 FastAPI WebSocket handlers will route by ``character_id``
-from the frontend session and call :meth:`get_or_create_agent`.
+:class:`src.agent.chat_agent.ChatAgent` per ``(character_id, user_id, chat_id)``
+tuple, caching each instance so subsequent requests reuse the same short-term
+memory state for that chat. Long-term memory handles are shared per
+``(character_id, user_id)`` so facts remain cross-chat for the same character.
 
 Key invariants (per docs/Phase4_执行规格.md §US-AGT-005 and decision S3):
 
-* Cache key is the **tuple** ``(character_id, user_id)`` -- same character
-  accessed by two users yields two independent :class:`MemoryManager`
-  instances (distinct ``user_id`` -> distinct mem0 filters).
+* Agent cache key is the **tuple** ``(character_id, user_id, chat_id)`` -- same
+  user/character in two chats gets two independent short-term memories.
+* Long-term memory cache key is ``(character_id, user_id)`` -- facts remain
+  shared across chats while still using distinct mem0 filters per user.
 * ``_safe_build_long_term`` is best-effort: if mem0 construction fails
   (missing API key, Qdrant unreachable, etc.) it logs a WARNING and returns
   ``None``; the resulting ChatAgent still works with short-term memory only.
@@ -24,16 +25,18 @@ docs/LLM调用层设计讨论.md §2.3 (role-based LLMFactory).
 ServiceContext——ChatAgent 生命周期的顶层拥有者（Phase 4，US-AGT-005）。
 
 每个进程持有一个 ServiceContext。它保存合并后的配置（来自
-:func:`src.utils.config_loader.load_config`），并按 ``(character_id, user_id)``
-元组懒加载构造 :class:`src.agent.chat_agent.ChatAgent`，缓存实例，使后续请求
-复用同一份记忆状态。Phase 5 的 FastAPI WebSocket 处理器将根据前端会话的
-``character_id`` 路由并调用 :meth:`get_or_create_agent`。
+:func:`src.utils.config_loader.load_config`），并按
+``(character_id, user_id, chat_id)`` 元组懒加载构造
+:class:`src.agent.chat_agent.ChatAgent`，缓存实例，使后续请求复用该聊天的短期
+记忆状态。长期记忆句柄按 ``(character_id, user_id)`` 共享，使同一角色下不同
+聊天标题共享长期事实。
 
 关键不变式（对齐 docs/Phase4_执行规格.md §US-AGT-005 和决策 S3）：
 
-* 缓存键是 ``(character_id, user_id)`` **元组**——同一角色被两个用户访问
-  会得到两个独立的 :class:`MemoryManager` 实例（不同的 ``user_id`` 对应
-  不同的 mem0 过滤器）。
+* Agent 缓存键是 ``(character_id, user_id, chat_id)`` **元组**——同一用户、
+  同一角色的不同聊天标题会得到独立的短期记忆。
+* 长期记忆缓存键是 ``(character_id, user_id)``——同一角色下不同聊天标题共享
+  长期事实，同时不同用户仍对应不同 mem0 过滤器。
 * ``_safe_build_long_term`` 尽力而为：若 mem0 构造失败（缺 API key、
   Qdrant 不可达等），记录 WARNING 并返回 ``None``；生成的 ChatAgent 仍能
   基于短期记忆工作。
@@ -115,29 +118,32 @@ class ServiceContext:
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
         self._agents: dict[tuple[str, str, str], ChatAgent] = {}
+        self._long_term_memories: dict[tuple[str, str], LongTermMemory | None] = {}
 
     def get_or_create_agent(self, character_id: str, user_id: str, chat_id: str) -> ChatAgent:
         """Return the cached agent for ``(character_id, user_id, chat_id)`` or build one.
 
         Creation path (US-AGT-005 PRD):
           1. ``persona = load_persona(character_id)``
-          2. ``long_term = _safe_build_long_term(config['memory']['mem0'])``
+          2. ``long_term = _get_or_create_long_term(character_id, user_id)``
           3. Build ``llm_factory_fn`` closure that defers to
              :func:`create_from_role` with the full ``llm`` config.
           4. Construct ``MemoryManager(config['memory'], llm_factory_fn,
-             character=character_id, user_id=user_id, long_term=long_term)``.
+             character=character_id, user_id=user_id, chat_id=chat_id,
+             long_term=long_term)``.
           5. Build the main-chat LLM via ``create_from_role('chat', ...)``.
           6. ``agent = ChatAgent(chat_llm, mgr, persona)``.
 
-        返回 ``(character_id, user_id)`` 对应的缓存 Agent；未命中则新建。
+        返回 ``(character_id, user_id, chat_id)`` 对应的缓存 Agent；未命中则新建。
 
         创建路径（US-AGT-005 PRD）：
           1. ``persona = load_persona(character_id)``
-          2. ``long_term = _safe_build_long_term(config['memory']['mem0'])``
+          2. ``long_term = _get_or_create_long_term(character_id, user_id)``
           3. 构造 ``llm_factory_fn`` 闭包，委托给携带完整 ``llm`` 配置的
              :func:`create_from_role`。
           4. 构造 ``MemoryManager(config['memory'], llm_factory_fn,
-             character=character_id, user_id=user_id, long_term=long_term)``。
+             character=character_id, user_id=user_id, chat_id=chat_id,
+             long_term=long_term)``。
           5. 通过 ``create_from_role('chat', ...)`` 构造主聊天 LLM。
           6. ``agent = ChatAgent(chat_llm, mgr, persona)``。
         """
@@ -148,10 +154,9 @@ class ServiceContext:
 
         llm_config = self.config.get("llm", {})
         memory_config = self.config.get("memory", {})
-        mem0_config = memory_config.get("mem0", {})
 
         persona = load_persona(character_id)
-        long_term = _safe_build_long_term(mem0_config)
+        long_term = self._get_or_create_long_term(character_id, user_id)
 
         def _llm_factory_fn(role: str) -> LLMInterface:
             return create_from_role(role, llm_config)
@@ -176,6 +181,20 @@ class ServiceContext:
             "on" if long_term is not None else "off",
         )
         return agent
+
+    def _get_or_create_long_term(
+        self,
+        character_id: str,
+        user_id: str,
+    ) -> LongTermMemory | None:
+        """Return the shared long-term memory handle for ``(character_id, user_id)``."""
+
+        key = (character_id, user_id)
+        if key not in self._long_term_memories:
+            memory_config = self.config.get("memory", {})
+            mem0_config = memory_config.get("mem0", {})
+            self._long_term_memories[key] = _safe_build_long_term(mem0_config)
+        return self._long_term_memories[key]
 
     def get_character_memory_dir(self, character_id: str, user_id: str) -> str:
         """Return and migrate the user-scoped local memory directory path."""
@@ -220,12 +239,9 @@ class ServiceContext:
         character_id: str,
         user_id: str,
     ) -> LongTermMemory | None:
-        """Return a cached agent's long-term memory handle, if one exists."""
+        """Return the cached long-term memory handle for ``(character_id, user_id)``."""
 
-        for (cached_character_id, cached_user_id, _chat_id), agent in self._agents.items():
-            if cached_character_id == character_id and cached_user_id == user_id:
-                return agent.memory_manager.long_term
-        return None
+        return self._long_term_memories.get((character_id, user_id))
 
     async def close_all(self) -> None:
         """Flush every cached agent's session and release long-term handles.
@@ -242,25 +258,26 @@ class ServiceContext:
         会话从未接收过轮次，也可在进程关闭期间安全调用。
         """
         logger.info("ServiceContext close_all | agent_count={}", len(self._agents))
-        for key, agent in self._agents.items():
+        for agent_key, agent in self._agents.items():
             try:
                 await agent.memory_manager.close_session()
             except Exception as exc:  # noqa: BLE001
                 logger.warning(
                     "close_session failed during close_all | key={} error={!r}",
-                    key,
+                    agent_key,
                     exc,
                 )
-            long_term = agent.memory_manager.long_term
-            if long_term is not None:
-                try:
-                    long_term.close()
-                except Exception as exc:  # noqa: BLE001
-                    logger.warning(
-                        "long_term.close failed during close_all | key={} error={!r}",
-                        key,
-                        exc,
-                    )
+        for memory_key, long_term in self._long_term_memories.items():
+            if long_term is None:
+                continue
+            try:
+                long_term.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "long_term.close failed during close_all | key={} error={!r}",
+                    memory_key,
+                    exc,
+                )
         logger.info("ServiceContext close_all complete")
 
 

--- a/src/service_context.py
+++ b/src/service_context.py
@@ -52,7 +52,12 @@ from src.agent.persona import load_persona
 from src.llm.factory import create_from_role
 from src.llm.interface import LLMInterface
 from src.memory.long_term import LongTermMemory
-from src.memory.manager import MemoryManager, legacy_character_dir, resolve_user_character_dir
+from src.memory.manager import (
+    MemoryManager,
+    legacy_character_dir,
+    resolve_user_character_chat_dir,
+    resolve_user_character_dir,
+)
 
 
 def _safe_build_long_term(mem0_config: dict[str, Any]) -> LongTermMemory | None:
@@ -109,10 +114,10 @@ class ServiceContext:
 
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
-        self._agents: dict[tuple[str, str], ChatAgent] = {}
+        self._agents: dict[tuple[str, str, str], ChatAgent] = {}
 
-    def get_or_create_agent(self, character_id: str, user_id: str) -> ChatAgent:
-        """Return the cached agent for ``(character_id, user_id)`` or build a new one.
+    def get_or_create_agent(self, character_id: str, user_id: str, chat_id: str) -> ChatAgent:
+        """Return the cached agent for ``(character_id, user_id, chat_id)`` or build one.
 
         Creation path (US-AGT-005 PRD):
           1. ``persona = load_persona(character_id)``
@@ -136,7 +141,7 @@ class ServiceContext:
           5. 通过 ``create_from_role('chat', ...)`` 构造主聊天 LLM。
           6. ``agent = ChatAgent(chat_llm, mgr, persona)``。
         """
-        key = (character_id, user_id)
+        key = (character_id, user_id, chat_id)
         cached = self._agents.get(key)
         if cached is not None:
             return cached
@@ -156,6 +161,7 @@ class ServiceContext:
             _llm_factory_fn,
             character=character_id,
             user_id=user_id,
+            chat_id=chat_id,
             long_term=long_term,
         )
         chat_llm = create_from_role("chat", llm_config)
@@ -163,9 +169,10 @@ class ServiceContext:
 
         self._agents[key] = agent
         logger.info(
-            "ChatAgent created | character={} | user_id={} | long_term={}",
+            "ChatAgent created | character={} | user_id={} | chat_id={} | long_term={}",
             character_id,
             user_id,
+            chat_id,
             "on" if long_term is not None else "off",
         )
         return agent
@@ -176,21 +183,32 @@ class ServiceContext:
         memory_config = self.config.get("memory", {})
         return str(resolve_user_character_dir(memory_config, user_id, character_id))
 
+    def get_character_chat_memory_dir(
+        self,
+        character_id: str,
+        user_id: str,
+        chat_id: str,
+    ) -> str:
+        """Return and migrate the chat-scoped local memory directory path."""
+
+        memory_config = self.config.get("memory", {})
+        return str(resolve_user_character_chat_dir(memory_config, user_id, character_id, chat_id))
+
     def get_legacy_character_memory_dir(self, character_id: str) -> str:
         """Return the legacy pre-user-scope local memory directory path."""
 
         memory_config = self.config.get("memory", {})
         return str(legacy_character_dir(memory_config, character_id))
 
-    def reset_short_term_memory(self, character_id: str, user_id: str) -> bool:
-        """Hot-clear cached short-term memory for ``(character_id, user_id)``.
+    def reset_short_term_memory(self, character_id: str, user_id: str, chat_id: str) -> bool:
+        """Hot-clear cached short-term memory for ``(character_id, user_id, chat_id)``.
 
         Returns ``True`` when a cached agent existed and was reset. A ``False``
         return means the route only needs to delete persisted files because no
         in-process memory state is alive yet.
         """
 
-        agent = self._agents.get((character_id, user_id))
+        agent = self._agents.get((character_id, user_id, chat_id))
         if agent is None:
             return False
 
@@ -204,10 +222,12 @@ class ServiceContext:
     ) -> LongTermMemory | None:
         """Return a cached agent's long-term memory handle, if one exists."""
 
-        agent = self._agents.get((character_id, user_id))
-        if agent is None:
-            return None
-        return agent.memory_manager.long_term
+        for cached_character_id, cached_user_id, _chat_id in self._agents:
+            if cached_character_id == character_id and cached_user_id == user_id:
+                return self._agents[
+                    (cached_character_id, cached_user_id, _chat_id)
+                ].memory_manager.long_term
+        return None
 
     async def close_all(self) -> None:
         """Flush every cached agent's session and release long-term handles.

--- a/src/service_context.py
+++ b/src/service_context.py
@@ -222,11 +222,9 @@ class ServiceContext:
     ) -> LongTermMemory | None:
         """Return a cached agent's long-term memory handle, if one exists."""
 
-        for cached_character_id, cached_user_id, _chat_id in self._agents:
+        for (cached_character_id, cached_user_id, _chat_id), agent in self._agents.items():
             if cached_character_id == character_id and cached_user_id == user_id:
-                return self._agents[
-                    (cached_character_id, cached_user_id, _chat_id)
-                ].memory_manager.long_term
+                return agent.memory_manager.long_term
         return None
 
     async def close_all(self) -> None:

--- a/src/storage/db_storage.py
+++ b/src/storage/db_storage.py
@@ -21,6 +21,11 @@ class DatabaseChatStorage(ChatStorageInterface):
     async def get_chat_for_user(self, user_id: str, chat_id: str) -> dict | None:
         raise NotImplementedError("Database storage is reserved for Phase 7")
 
+    async def get_chat_for_user_character(
+        self, user_id: str, character_id: str, chat_id: str
+    ) -> dict | None:
+        raise NotImplementedError("Database storage is reserved for Phase 7")
+
     async def update_chat(self, chat_id: str, **kwargs: str) -> dict:
         raise NotImplementedError("Database storage is reserved for Phase 7")
 

--- a/src/storage/interface.py
+++ b/src/storage/interface.py
@@ -68,6 +68,23 @@ class ChatStorageInterface(ABC):
         ...
 
     @abstractmethod
+    async def get_chat_for_user_character(
+        self, user_id: str, character_id: str, chat_id: str
+    ) -> dict | None:
+        """
+        Get chat metadata by ID, scoped to a user and character.
+
+        Args:
+            user_id: User identifier
+            character_id: Character identifier
+            chat_id: Chat identifier
+
+        Returns:
+            Chat metadata dict or None if not found for this user/character
+        """
+        ...
+
+    @abstractmethod
     async def update_chat(self, chat_id: str, **kwargs: str) -> dict:
         """
         Update chat metadata (e.g., title).

--- a/src/storage/json_storage.py
+++ b/src/storage/json_storage.py
@@ -4,7 +4,7 @@ import asyncio
 import json
 import uuid
 from datetime import UTC, datetime
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import NamedTuple
 
 from src.memory._io_utils import atomic_replace
@@ -17,6 +17,23 @@ class _ChatLocation(NamedTuple):
     chat: dict
 
 
+def _validate_path_component(label: str, value: str) -> str:
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string")
+    clean = value.strip()
+    path = PurePath(clean)
+    if (
+        not clean
+        or clean in {".", ".."}
+        or path.is_absolute()
+        or len(path.parts) != 1
+        or "/" in clean
+        or "\\" in clean
+    ):
+        raise ValueError(f"Invalid {label}: {value!r}")
+    return clean
+
+
 class JSONChatStorage(ChatStorageInterface):
     """JSON file-based chat storage with file system persistence."""
 
@@ -25,7 +42,9 @@ class JSONChatStorage(ChatStorageInterface):
 
     def _get_user_dir(self, user_id: str, character_id: str) -> Path:
         """Get user-character directory path."""
-        return self.base_path / user_id / character_id
+        safe_user_id = _validate_path_component("user_id", user_id)
+        safe_character_id = _validate_path_component("character_id", character_id)
+        return self.base_path / safe_user_id / safe_character_id
 
     def _get_index_path(self, user_id: str, character_id: str) -> Path:
         """Get index.json path."""
@@ -33,7 +52,8 @@ class JSONChatStorage(ChatStorageInterface):
 
     def _get_session_path(self, user_id: str, character_id: str, chat_id: str) -> Path:
         """Get session file path."""
-        return self._get_user_dir(user_id, character_id) / "sessions" / f"{chat_id}.json"
+        safe_chat_id = _validate_path_component("chat_id", chat_id)
+        return self._get_user_dir(user_id, character_id) / "sessions" / f"{safe_chat_id}.json"
 
     async def _read_json(self, path: Path) -> dict | list | None:
         """Read JSON file asynchronously."""
@@ -78,22 +98,43 @@ class JSONChatStorage(ChatStorageInterface):
         return f"{date_str}_{uuid_str}"
 
     async def _find_chat_location(
-        self, chat_id: str, user_id: str | None = None
+        self,
+        chat_id: str,
+        user_id: str | None = None,
+        character_id: str | None = None,
     ) -> _ChatLocation | None:
-        """Find a chat location, optionally scoped to one user."""
+        """Find a chat location, optionally scoped to one user/character."""
+        safe_chat_id = _validate_path_component("chat_id", chat_id)
+        safe_user_id = (
+            _validate_path_component("user_id", user_id) if user_id is not None else None
+        )
+        safe_character_id = (
+            _validate_path_component("character_id", character_id)
+            if character_id is not None
+            else None
+        )
         if not self.base_path.is_dir():
             return None
 
-        user_dirs = [self.base_path / user_id] if user_id else list(self.base_path.iterdir())
+        user_dirs = (
+            [self.base_path / safe_user_id]
+            if safe_user_id is not None
+            else list(self.base_path.iterdir())
+        )
         for user_dir in user_dirs:
             if not user_dir.is_dir():
                 continue
-            for char_dir in user_dir.iterdir():
+            char_dirs = (
+                [user_dir / safe_character_id]
+                if safe_character_id is not None
+                else list(user_dir.iterdir())
+            )
+            for char_dir in char_dirs:
                 if not char_dir.is_dir():
                     continue
                 index = await self._load_index(user_dir.name, char_dir.name)
                 for chat in index["chats"]:
-                    if chat["id"] == chat_id:
+                    if chat["id"] == safe_chat_id:
                         return _ChatLocation(user_dir.name, char_dir.name, chat)
         return None
 
@@ -130,11 +171,12 @@ class JSONChatStorage(ChatStorageInterface):
         else:
             # Aggregate across all characters
             chats = []
-            user_dir = self.base_path / user_id
+            safe_user_id = _validate_path_component("user_id", user_id)
+            user_dir = self.base_path / safe_user_id
             if user_dir.exists():
                 for char_dir in user_dir.iterdir():
                     if char_dir.is_dir():
-                        index = await self._load_index(user_id, char_dir.name)
+                        index = await self._load_index(safe_user_id, char_dir.name)
                         chats.extend(index["chats"])
 
         # Sort by updated_at descending
@@ -149,6 +191,17 @@ class JSONChatStorage(ChatStorageInterface):
     async def get_chat_for_user(self, user_id: str, chat_id: str) -> dict | None:
         """Get chat metadata by ID, scoped to a user."""
         location = await self._find_chat_location(chat_id, user_id=user_id)
+        return location.chat if location else None
+
+    async def get_chat_for_user_character(
+        self, user_id: str, character_id: str, chat_id: str
+    ) -> dict | None:
+        """Get chat metadata by ID, scoped to one user-character index."""
+        location = await self._find_chat_location(
+            chat_id,
+            user_id=user_id,
+            character_id=character_id,
+        )
         return location.chat if location else None
 
     async def update_chat(self, chat_id: str, **kwargs: str) -> dict:

--- a/tests/agent/test_live_chat_agent.py
+++ b/tests/agent/test_live_chat_agent.py
@@ -206,9 +206,9 @@ def _build_full_config(env: dict[str, str], characters_dir: Path) -> dict[str, A
                     "max_single_message_tokens": 800,
                 },
                 "collapse": {
-                    "trigger_rounds": 26,
+                    "trigger_rounds": 20,
                     "compress_rounds": 20,
-                    "keep_recent_rounds": 6,
+                    "keep_recent_rounds": 20,
                 },
                 "super_compact": {"trigger_blocks": 4},
                 "compressor": {"l3_role": "l3_compress", "l4_role": "l4_compact"},
@@ -232,9 +232,9 @@ def _build_offline_memory_config(characters_dir: Path) -> dict[str, Any]:
         "short_term": {
             "snip": {"filler_words": []},
             "collapse": {
-                "trigger_rounds": 26,
+                "trigger_rounds": 20,
                 "compress_rounds": 20,
-                "keep_recent_rounds": 6,
+                "keep_recent_rounds": 20,
             },
             "super_compact": {"trigger_blocks": 4},
             "compressor": {"l3_role": "l3_compress", "l4_role": "l4_compact"},
@@ -256,7 +256,7 @@ async def test_live_chat_agent_ten_rounds(tmp_path: Path) -> None:
     Structural assertions (after 10 rounds, before probes):
       * chat_history.json has exactly 21 JSON objects (1 metadata + 10 human + 10 ai)
       * short_term_memory.json: total_rounds=10, recent_messages len=20,
-        active_blocks and meta_blocks both empty (L3 trigger=26, not reached)
+        active_blocks and meta_blocks both empty (raw tail has not reached 40 rounds)
 
     Recall probes (round 11, 12) drive the real LLM and assert the user
     facts revealed in round 1 are still reachable via ``recent_messages``
@@ -278,7 +278,7 @@ async def test_live_chat_agent_ten_rounds(tmp_path: Path) -> None:
     config = _build_full_config(env, tmp_path)
 
     ctx = ServiceContext(config)
-    agent = ctx.get_or_create_agent("atri", user_id="pytest_alice")
+    agent = ctx.get_or_create_agent("atri", user_id="pytest_alice", chat_id="live-test")
 
     conversations = [
         "我叫 Alice，最爱喝珍珠奶茶",

--- a/tests/memory/test_live_memory.py
+++ b/tests/memory/test_live_memory.py
@@ -95,9 +95,9 @@ def _memory_config_sdk(mem0_api_key: str) -> dict[str, Any]:
                 "max_single_message_tokens": 800,
             },
             "collapse": {
-                "trigger_rounds": 26,
+                "trigger_rounds": 20,
                 "compress_rounds": 20,
-                "keep_recent_rounds": 6,
+                "keep_recent_rounds": 20,
             },
             "super_compact": {"trigger_blocks": 4},
             "compressor": {

--- a/tests/memory/test_manager.py
+++ b/tests/memory/test_manager.py
@@ -1,9 +1,9 @@
 """Tests for src/memory/manager.py -- round-driven trigger scheduling.
 
 Covers PRD US-MEM-005 acceptance criteria:
-  * 25 rounds -> no L3 trigger
-  * exactly 26 rounds -> L3 fires, one block appended
-  * 52 rounds -> L3 fires twice, two blocks
+  * 20 rounds -> no L3 trigger
+  * 40 rounds -> L3 fires, one block appended, latest 20 rounds stay raw
+  * 60 rounds -> L3 fires twice, two blocks
   * 4 blocks accumulated -> L4 fires once, meta_blocks grows, active_blocks resets
   * invalid round (ai content starts with 'Error') does not increment total
 
@@ -40,7 +40,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from src.memory.chat_history import ChatHistoryWriter
-from src.memory.manager import MemoryManager, _is_valid_round, resolve_user_character_dir
+from src.memory.manager import (
+    MemoryManager,
+    _is_valid_round,
+    resolve_user_character_chat_dir,
+    resolve_user_character_dir,
+)
 from src.memory.short_term import ShortTermStore
 
 # ---------------------------------------------------------------------------
@@ -58,9 +63,9 @@ def _default_config() -> dict[str, Any]:
                 "max_single_message_tokens": 800,
             },
             "collapse": {
-                "trigger_rounds": 26,
+                "trigger_rounds": 20,
                 "compress_rounds": 20,
-                "keep_recent_rounds": 6,
+                "keep_recent_rounds": 20,
             },
             "super_compact": {"trigger_blocks": 4},
             "compressor": {
@@ -166,6 +171,61 @@ def test_resolve_user_character_dir_does_not_remigrate_after_marker(tmp_path: Pa
     assert not (target / "short_term_memory.json").exists()
 
 
+def test_resolve_user_character_chat_dir_copies_character_scope_memory_once(
+    tmp_path: Path,
+) -> None:
+    characters_root = tmp_path / "characters"
+    character_dir = characters_root / "alice" / "atri"
+    character_dir.mkdir(parents=True)
+    (character_dir / "short_term_memory.json").write_text(
+        json.dumps({"session_id": "character-scope"}),
+        encoding="utf-8",
+    )
+
+    chat_dir = resolve_user_character_chat_dir(
+        {"storage": {"characters_dir": str(characters_root)}},
+        "alice",
+        "atri",
+        "chat-a",
+    )
+
+    assert chat_dir == character_dir / "chats" / "chat-a"
+    copied = json.loads((chat_dir / "short_term_memory.json").read_text(encoding="utf-8"))
+    assert copied["session_id"] == "character-scope"
+    assert (character_dir / "short_term_memory.json").is_file()
+    assert (character_dir / ".chat_scope_migrated").is_file()
+
+    chat_b = resolve_user_character_chat_dir(
+        {"storage": {"characters_dir": str(characters_root)}},
+        "alice",
+        "atri",
+        "chat-b",
+    )
+    assert not (chat_b / "short_term_memory.json").exists()
+
+
+def test_memory_manager_chat_id_uses_chat_scoped_directory(tmp_path: Path) -> None:
+    config = {"storage": {"characters_dir": str(tmp_path / "characters")}}
+
+    chat_a = MemoryManager(
+        config,
+        _make_factory(),
+        character="atri",
+        user_id="alice",
+        chat_id="chat-a",
+    )
+    chat_b = MemoryManager(
+        config,
+        _make_factory(),
+        character="atri",
+        user_id="alice",
+        chat_id="chat-b",
+    )
+
+    assert chat_a.character_dir == tmp_path / "characters" / "alice" / "atri" / "chats" / "chat-a"
+    assert chat_b.character_dir == tmp_path / "characters" / "alice" / "atri" / "chats" / "chat-b"
+
+
 @pytest.mark.asyncio
 async def test_reset_short_term_hot_clears_memory_and_file(tmp_path: Path) -> None:
     mgr = _new_manager(tmp_path)
@@ -247,43 +307,68 @@ def test_is_valid_round_rejects_missing_content() -> None:
 
 
 @pytest.mark.asyncio
-async def test_25_rounds_does_not_trigger_l3(tmp_path: Path) -> None:
+async def test_20_rounds_does_not_trigger_l3(tmp_path: Path) -> None:
     mgr = _new_manager(tmp_path)
-    for _ in range(25):
+    for _ in range(20):
         await mgr.on_round_complete(_human(), _ai())
-    assert mgr.state["total_rounds"] == 25
+    assert mgr.state["total_rounds"] == 20
     assert mgr.state["active_blocks"] == []
     assert mgr.state["meta_blocks"] == []
-    # All 25 rounds * 2 = 50 messages stay in recent_messages.
-    # 全部 25 轮 * 2 = 50 条消息保留在 recent_messages 中。
-    assert len(mgr.state["recent_messages"]) == 50
+    assert len(mgr.state["recent_messages"]) == 40
 
 
 @pytest.mark.asyncio
-async def test_exactly_26_rounds_triggers_l3_once(tmp_path: Path) -> None:
+async def test_40_rounds_triggers_l3_once_and_keeps_latest_20(tmp_path: Path) -> None:
     mgr = _new_manager(tmp_path)
-    for _ in range(26):
-        await mgr.on_round_complete(_human(), _ai())
-    assert mgr.state["total_rounds"] == 26
+    for index in range(40):
+        await mgr.on_round_complete(_human(f"h{index + 1}"), _ai(f"a{index + 1}"))
+    assert mgr.state["total_rounds"] == 40
     assert len(mgr.state["active_blocks"]) == 1
     assert mgr.state["active_blocks"][0]["covers_rounds"] == [1, 20]
-    # 20 rounds compressed -> 40 head msgs popped; 6 rounds remain = 12 msgs.
-    # 压缩 20 轮 -> 弹出头部 40 条消息；余下 6 轮 = 12 条消息。
-    assert len(mgr.state["recent_messages"]) == 12
+    assert len(mgr.state["recent_messages"]) == 40
+    assert mgr.state["recent_messages"][0]["content"] == "h21"
+    assert mgr.state["recent_messages"][-1]["content"] == "a40"
 
 
 @pytest.mark.asyncio
-async def test_52_rounds_triggers_l3_twice(tmp_path: Path) -> None:
+async def test_41_rounds_keeps_l3_plus_latest_21_raw_rounds(tmp_path: Path) -> None:
     mgr = _new_manager(tmp_path)
-    for _ in range(52):
-        await mgr.on_round_complete(_human(), _ai())
-    assert mgr.state["total_rounds"] == 52
+    for index in range(41):
+        await mgr.on_round_complete(_human(f"h{index + 1}"), _ai(f"a{index + 1}"))
+    assert mgr.state["total_rounds"] == 41
+    assert len(mgr.state["active_blocks"]) == 1
+    assert mgr.state["active_blocks"][0]["covers_rounds"] == [1, 20]
+    assert len(mgr.state["recent_messages"]) == 42
+    assert mgr.state["recent_messages"][0]["content"] == "h21"
+    assert mgr.state["recent_messages"][-1]["content"] == "a41"
+
+
+@pytest.mark.asyncio
+async def test_60_rounds_triggers_l3_twice_and_keeps_latest_20(tmp_path: Path) -> None:
+    mgr = _new_manager(tmp_path)
+    for index in range(60):
+        await mgr.on_round_complete(_human(f"h{index + 1}"), _ai(f"a{index + 1}"))
+    assert mgr.state["total_rounds"] == 60
     assert len(mgr.state["active_blocks"]) == 2
     assert mgr.state["active_blocks"][0]["covers_rounds"] == [1, 20]
     assert mgr.state["active_blocks"][1]["covers_rounds"] == [21, 40]
-    # 12 rounds remain = 24 msgs (52 total - 40 compressed).
-    # 余下 12 轮 = 24 条消息（总计 52 - 压缩 40）。
-    assert len(mgr.state["recent_messages"]) == 24
+    assert len(mgr.state["recent_messages"]) == 40
+    assert mgr.state["recent_messages"][0]["content"] == "h41"
+    assert mgr.state["recent_messages"][-1]["content"] == "a60"
+
+
+@pytest.mark.asyncio
+async def test_78_rounds_keeps_latest_38_raw_rounds(tmp_path: Path) -> None:
+    mgr = _new_manager(tmp_path)
+    for index in range(78):
+        await mgr.on_round_complete(_human(f"h{index + 1}"), _ai(f"a{index + 1}"))
+    assert mgr.state["total_rounds"] == 78
+    assert len(mgr.state["active_blocks"]) == 2
+    assert mgr.state["active_blocks"][0]["covers_rounds"] == [1, 20]
+    assert mgr.state["active_blocks"][1]["covers_rounds"] == [21, 40]
+    assert len(mgr.state["recent_messages"]) == 76
+    assert mgr.state["recent_messages"][0]["content"] == "h41"
+    assert mgr.state["recent_messages"][-1]["content"] == "a78"
 
 
 @pytest.mark.asyncio
@@ -293,11 +378,9 @@ async def test_four_blocks_trigger_l4(tmp_path: Path) -> None:
     累计 4 个 L3 块 -> L4 触发，消耗全部 4 个块。
     """
     mgr = _new_manager(tmp_path)
-    # 104 rounds = four L3 triggers at rounds 26, 52, 78, 104.
-    # 104 轮 = 分别在第 26、52、78、104 轮触发 4 次 L3。
-    for _ in range(104):
+    for _ in range(100):
         await mgr.on_round_complete(_human(), _ai())
-    assert mgr.state["total_rounds"] == 104
+    assert mgr.state["total_rounds"] == 100
     # After 4 L3 triggers the active_blocks hit 4, L4 consumed them.
     # 4 次 L3 触发后 active_blocks 达到 4，L4 将其全部消耗。
     assert mgr.state["active_blocks"] == []
@@ -385,9 +468,7 @@ async def test_llm_factory_called_with_configured_roles(tmp_path: Path) -> None:
         return shared
 
     mgr = _new_manager(tmp_path, factory=factory)
-    # Up to round 26 -> triggers L3 once
-    # 执行到第 26 轮 -> 触发一次 L3
-    for _ in range(26):
+    for _ in range(40):
         await mgr.on_round_complete(_human(), _ai())
     assert seen.count("l3_compress") == 1
     assert "l4_compact" not in seen
@@ -425,7 +506,7 @@ async def test_l3_trigger_calls_long_term_add(tmp_path: Path) -> None:
         character_dir=tmp_path,
         long_term=long_term,
     )
-    for _ in range(26):
+    for _ in range(40):
         await mgr.on_round_complete(_human(), _ai())
 
     # L3 fired exactly once -> long_term.add awaited exactly once.
@@ -451,9 +532,9 @@ async def test_no_long_term_injection_skips_mem0_call(tmp_path: Path) -> None:
     """
     # long_term 默认为 None
     mgr = _new_manager(tmp_path)  # long_term defaults to None
-    for _ in range(26):
+    for _ in range(40):
         await mgr.on_round_complete(_human(), _ai())
-    assert mgr.state["total_rounds"] == 26
+    assert mgr.state["total_rounds"] == 40
     assert len(mgr.state["active_blocks"]) == 1
 
 
@@ -818,17 +899,17 @@ async def test_resume_behind_catches_up_tail(tmp_path: Path) -> None:
 
 @pytest.mark.asyncio
 async def test_resume_on_boundary_triggers_l3(tmp_path: Path) -> None:
-    """Stored total_rounds=20, chat_history=26 -> replay lands on 26 => L3 fires.
+    """Stored total_rounds=20, chat_history=40 -> replay keeps 20 raw rounds and fires L3.
 
     已存 total_rounds=20，chat_history=26 -> 重放至 26 => L3 触发。
     """
     session_id = "2026-04-19_c0ffee01"
-    _seed_session_files(tmp_path, session_id, "atri", stored_rounds=20, chat_rounds=26)
+    _seed_session_files(tmp_path, session_id, "atri", stored_rounds=20, chat_rounds=40)
     mgr, long_term = _make_manager_with_mock_long_term(tmp_path)
 
     await mgr.resume_session(session_id)
 
-    assert mgr.state["total_rounds"] == 26
+    assert mgr.state["total_rounds"] == 40
     assert len(mgr.state["active_blocks"]) == 1
     assert mgr.state["active_blocks"][0]["covers_rounds"] == [1, 20]
     # L3 trigger -> long_term.add invoked once with the 40-msg compress window.
@@ -837,7 +918,7 @@ async def test_resume_on_boundary_triggers_l3(tmp_path: Path) -> None:
     assert len(long_term.add.call_args.args[0]) == 40
     # 6 rounds remain raw = 12 msgs.
     # 保留 6 轮原始消息 = 12 条。
-    assert len(mgr.state["recent_messages"]) == 12
+    assert len(mgr.state["recent_messages"]) == 40
 
 
 @pytest.mark.asyncio
@@ -852,20 +933,20 @@ async def test_resume_corrupt_json_rebuilds_from_chat_history(tmp_path: Path) ->
         session_id,
         "atri",
         stored_rounds=0,
-        chat_rounds=26,
+        chat_rounds=40,
         short_term_body='{"this is not": valid json',
     )
     mgr, long_term = _make_manager_with_mock_long_term(tmp_path)
 
     await mgr.resume_session(session_id)
 
-    assert mgr.state["total_rounds"] == 26
+    assert mgr.state["total_rounds"] == 40
     assert len(mgr.state["active_blocks"]) == 1
     assert mgr.state["active_blocks"][0]["covers_rounds"] == [1, 20]
     # Rebuild replays L3 windows through long_term.add for idempotency.
     # 重建时通过 long_term.add 重放 L3 窗口以保证幂等性。
     long_term.add.assert_awaited_once()
-    assert len(mgr.state["recent_messages"]) == 12
+    assert len(mgr.state["recent_messages"]) == 40
 
 
 @pytest.mark.asyncio

--- a/tests/memory/test_manager.py
+++ b/tests/memory/test_manager.py
@@ -10,9 +10,9 @@ Covers PRD US-MEM-005 acceptance criteria:
 针对 src/memory/manager.py 的测试——按轮次驱动的触发调度。
 
 覆盖 PRD US-MEM-005 的验收标准：
-  * 25 轮 -> 不触发 L3
-  * 恰好 26 轮 -> L3 触发一次，追加一个块
-  * 52 轮 -> L3 触发两次，两个块
+  * 39 轮 -> 不触发 L3
+  * 恰好 40 轮 -> L3 触发一次，追加一个块并保留 20 轮原文
+  * 60 轮 -> L3 触发两次，两个块并保留 20 轮原文
   * 累计 4 个块 -> L4 触发一次，meta_blocks 增长，active_blocks 重置
   * 无效轮次（ai 内容以 'Error' 开头）不增加 total_rounds
 
@@ -202,6 +202,29 @@ def test_resolve_user_character_chat_dir_copies_character_scope_memory_once(
         "chat-b",
     )
     assert not (chat_b / "short_term_memory.json").exists()
+
+
+@pytest.mark.parametrize(
+    ("user_id", "character", "chat_id"),
+    [
+        ("../alice", "atri", "chat-a"),
+        ("alice", "../atri", "chat-a"),
+        ("alice", "atri", "../outside"),
+        ("alice", "atri", "nested/chat"),
+        ("alice", "atri", r"nested\chat"),
+        ("alice", "atri", ""),
+    ],
+)
+def test_resolve_user_character_chat_dir_rejects_unsafe_path_components(
+    tmp_path: Path,
+    user_id: str,
+    character: str,
+    chat_id: str,
+) -> None:
+    config = {"storage": {"characters_dir": str(tmp_path / "characters")}}
+
+    with pytest.raises(ValueError, match="Invalid|must be"):
+        resolve_user_character_chat_dir(config, user_id, character, chat_id)
 
 
 def test_memory_manager_chat_id_uses_chat_scoped_directory(tmp_path: Path) -> None:
@@ -892,8 +915,8 @@ async def test_resume_behind_catches_up_tail(tmp_path: Path) -> None:
     # 尾部内容来自 chat_history 中追加的消息对。
     assert mgr.state["recent_messages"][-2]["content"] == "h11"
     assert mgr.state["recent_messages"][-1]["content"] == "a11"
-    # No L3 boundary crossed (12 < 26), no long_term.add invoked.
-    # 未越过 L3 边界（12 < 26），故 long_term.add 未被调用。
+    # No L3 boundary crossed (12 < 40), no long_term.add invoked.
+    # 未越过 L3 边界（12 < 40），故 long_term.add 未被调用。
     long_term.add.assert_not_awaited()
 
 
@@ -901,7 +924,7 @@ async def test_resume_behind_catches_up_tail(tmp_path: Path) -> None:
 async def test_resume_on_boundary_triggers_l3(tmp_path: Path) -> None:
     """Stored total_rounds=20, chat_history=40 -> replay keeps 20 raw rounds and fires L3.
 
-    已存 total_rounds=20，chat_history=26 -> 重放至 26 => L3 触发。
+    已存 total_rounds=20，chat_history=40 -> 重放至 40 => L3 触发。
     """
     session_id = "2026-04-19_c0ffee01"
     _seed_session_files(tmp_path, session_id, "atri", stored_rounds=20, chat_rounds=40)
@@ -916,8 +939,8 @@ async def test_resume_on_boundary_triggers_l3(tmp_path: Path) -> None:
     # L3 触发 -> long_term.add 被调用一次，传入 40 条消息的压缩窗口。
     long_term.add.assert_awaited_once()
     assert len(long_term.add.call_args.args[0]) == 40
-    # 6 rounds remain raw = 12 msgs.
-    # 保留 6 轮原始消息 = 12 条。
+    # 20 rounds remain raw = 40 msgs.
+    # 保留 20 轮原始消息 = 40 条。
     assert len(mgr.state["recent_messages"]) == 40
 
 

--- a/tests/routes/test_chat_ws.py
+++ b/tests/routes/test_chat_ws.py
@@ -1,0 +1,171 @@
+"""Executable tests for WebSocket chat endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from src.app import create_app
+
+
+@pytest.fixture
+def mock_config() -> dict:
+    return {
+        "server": {
+            "cors": {
+                "enabled": True,
+                "allow_origins": ["*"],
+                "allow_methods": ["*"],
+                "allow_credentials": True,
+            }
+        },
+        "storage": {"mode": "json", "json": {"base_path": "data/chats"}},
+        "auth": {"enabled": False},
+        "llm": {},
+        "memory": {},
+    }
+
+
+@pytest.fixture
+def mock_service_context() -> tuple[MagicMock, MagicMock]:
+    mock_agent = MagicMock()
+    mock_context = MagicMock()
+    mock_context.get_or_create_agent.return_value = mock_agent
+    return mock_context, mock_agent
+
+
+@pytest.fixture
+def mock_storage() -> AsyncMock:
+    storage = AsyncMock()
+    storage.get_chat_for_user = AsyncMock(
+        return_value={"id": "test_chat_123", "character_id": "atri"}
+    )
+    storage.append_message_for_user = AsyncMock()
+    return storage
+
+
+async def _mock_chat_stream(chunks: list[str]) -> AsyncIterator[str]:
+    for chunk in chunks:
+        yield chunk
+
+
+def _make_app(config: dict, service_context: MagicMock, storage: AsyncMock):
+    with (
+        patch("src.app.ServiceContext", return_value=service_context),
+        patch("src.app.create_chat_storage", return_value=storage),
+    ):
+        app = create_app(config)
+        app.state.service_context = service_context
+        app.state.storage = storage
+        return app
+
+
+@pytest.mark.asyncio
+async def test_websocket_text_input_streaming(
+    mock_config: dict,
+    mock_service_context: tuple[MagicMock, MagicMock],
+    mock_storage: AsyncMock,
+) -> None:
+    mock_context, mock_agent = mock_service_context
+    chunks = ["你好", "，", "主人", "！"]
+    mock_agent.chat = MagicMock(side_effect=lambda text: _mock_chat_stream(chunks))
+    app = _make_app(mock_config, mock_context, mock_storage)
+
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_json(
+            {
+                "type": "input:text",
+                "data": {
+                    "text": "你好",
+                    "chat_id": "test_chat_123",
+                    "character_id": "atri",
+                },
+            }
+        )
+
+        for chunk in chunks:
+            response = websocket.receive_json()
+            assert response["type"] == "output:chat:chunk"
+            assert response["data"]["chunk"] == chunk
+
+        complete_response = websocket.receive_json()
+        assert complete_response["type"] == "output:chat:complete"
+        assert complete_response["data"]["full_reply"] == "".join(chunks)
+
+    mock_storage.get_chat_for_user.assert_awaited_once_with("default", "test_chat_123")
+    mock_context.get_or_create_agent.assert_called_once_with("atri", "default", "test_chat_123")
+    mock_storage.append_message_for_user.assert_any_call(
+        "default", "test_chat_123", "human", "你好", name="default"
+    )
+    mock_storage.append_message_for_user.assert_any_call(
+        "default", "test_chat_123", "ai", "你好，主人！", name="atri"
+    )
+
+
+@pytest.mark.asyncio
+async def test_websocket_rejects_missing_chat(
+    mock_config: dict,
+    mock_service_context: tuple[MagicMock, MagicMock],
+    mock_storage: AsyncMock,
+) -> None:
+    mock_context, _mock_agent = mock_service_context
+    mock_storage.get_chat_for_user.return_value = None
+    app = _make_app(mock_config, mock_context, mock_storage)
+
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_json(
+            {
+                "type": "input:text",
+                "data": {
+                    "text": "hello",
+                    "chat_id": "../outside",
+                    "character_id": "atri",
+                },
+            }
+        )
+
+        response = websocket.receive_json()
+        assert response["type"] == "error"
+        assert "not found" in response["data"]["message"]
+
+    mock_storage.get_chat_for_user.assert_awaited_once_with("default", "../outside")
+    mock_context.get_or_create_agent.assert_not_called()
+    mock_storage.append_message_for_user.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_websocket_rejects_character_mismatch(
+    mock_config: dict,
+    mock_service_context: tuple[MagicMock, MagicMock],
+    mock_storage: AsyncMock,
+) -> None:
+    mock_context, _mock_agent = mock_service_context
+    mock_storage.get_chat_for_user.return_value = {
+        "id": "test_chat_123",
+        "character_id": "bilibili",
+    }
+    app = _make_app(mock_config, mock_context, mock_storage)
+
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_json(
+            {
+                "type": "input:text",
+                "data": {
+                    "text": "hello",
+                    "chat_id": "test_chat_123",
+                    "character_id": "atri",
+                },
+            }
+        )
+
+        response = websocket.receive_json()
+        assert response["type"] == "error"
+        assert "not found" in response["data"]["message"]
+
+    mock_context.get_or_create_agent.assert_not_called()
+    mock_storage.append_message_for_user.assert_not_called()

--- a/tests/routes/test_chat_ws.py
+++ b/tests/routes/test_chat_ws.py
@@ -40,7 +40,7 @@ def mock_service_context() -> tuple[MagicMock, MagicMock]:
 @pytest.fixture
 def mock_storage() -> AsyncMock:
     storage = AsyncMock()
-    storage.get_chat_for_user = AsyncMock(
+    storage.get_chat_for_user_character = AsyncMock(
         return_value={"id": "test_chat_123", "character_id": "atri"}
     )
     storage.append_message_for_user = AsyncMock()
@@ -96,7 +96,9 @@ async def test_websocket_text_input_streaming(
         assert complete_response["type"] == "output:chat:complete"
         assert complete_response["data"]["full_reply"] == "".join(chunks)
 
-    mock_storage.get_chat_for_user.assert_awaited_once_with("default", "test_chat_123")
+    mock_storage.get_chat_for_user_character.assert_awaited_once_with(
+        "default", "atri", "test_chat_123"
+    )
     mock_context.get_or_create_agent.assert_called_once_with("atri", "default", "test_chat_123")
     mock_storage.append_message_for_user.assert_any_call(
         "default", "test_chat_123", "human", "你好", name="default"
@@ -113,7 +115,7 @@ async def test_websocket_rejects_missing_chat(
     mock_storage: AsyncMock,
 ) -> None:
     mock_context, _mock_agent = mock_service_context
-    mock_storage.get_chat_for_user.return_value = None
+    mock_storage.get_chat_for_user_character.return_value = None
     app = _make_app(mock_config, mock_context, mock_storage)
 
     client = TestClient(app)
@@ -133,9 +135,45 @@ async def test_websocket_rejects_missing_chat(
         assert response["type"] == "error"
         assert "not found" in response["data"]["message"]
 
-    mock_storage.get_chat_for_user.assert_awaited_once_with("default", "../outside")
+    mock_storage.get_chat_for_user_character.assert_awaited_once_with(
+        "default", "atri", "../outside"
+    )
     mock_context.get_or_create_agent.assert_not_called()
     mock_storage.append_message_for_user.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_websocket_rejects_invalid_chat_path(
+    mock_config: dict,
+    mock_service_context: tuple[MagicMock, MagicMock],
+    mock_storage: AsyncMock,
+) -> None:
+    mock_context, _mock_agent = mock_service_context
+    mock_storage.get_chat_for_user_character.side_effect = ValueError(
+        "Invalid chat_id: '../outside'"
+    )
+    app = _make_app(mock_config, mock_context, mock_storage)
+
+    client = TestClient(app)
+    with client.websocket_connect("/ws") as websocket:
+        websocket.send_json(
+            {
+                "type": "input:text",
+                "data": {
+                    "text": "hello",
+                    "chat_id": "../outside",
+                    "character_id": "atri",
+                },
+            }
+        )
+
+        response = websocket.receive_json()
+        assert response["type"] == "error"
+        assert "Invalid chat request" in response["data"]["message"]
+
+    mock_context.get_or_create_agent.assert_not_called()
+    mock_storage.append_message_for_user.assert_not_called()
+
 
 @pytest.mark.asyncio
 async def test_websocket_rejects_character_mismatch(
@@ -144,7 +182,7 @@ async def test_websocket_rejects_character_mismatch(
     mock_storage: AsyncMock,
 ) -> None:
     mock_context, _mock_agent = mock_service_context
-    mock_storage.get_chat_for_user.return_value = {
+    mock_storage.get_chat_for_user_character.return_value = {
         "id": "test_chat_123",
         "character_id": "bilibili",
     }

--- a/tests/routes/test_data.py
+++ b/tests/routes/test_data.py
@@ -165,6 +165,21 @@ async def test_clear_short_term_memory_does_not_restore_previously_migrated_lega
 
 
 @pytest.mark.asyncio
+async def test_clear_short_term_memory_rejects_invalid_chat_path(tmp_path: Path) -> None:
+    config = _test_config(tmp_path)
+    app = create_app(config)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        async with app.router.lifespan_context(app):
+            response = await client.delete(
+                "/api/data/characters/atri/chats/nested%5Coutside/short-term-memory"
+            )
+
+    assert response.status_code == 400
+    assert "Invalid" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_clear_long_term_memory_submits_mem0_delete(tmp_path: Path) -> None:
     config = _test_config(tmp_path)
     app = create_app(config)

--- a/tests/routes/test_data.py
+++ b/tests/routes/test_data.py
@@ -177,9 +177,7 @@ async def test_clear_long_term_memory_submits_mem0_delete(tmp_path: Path) -> Non
                 "event_id": "evt-test",
             }
             mock_long_term.close = lambda: None
-            app.state.service_context._agents[("atri", "default", "chat-a")] = SimpleNamespace(
-                memory_manager=SimpleNamespace(long_term=mock_long_term)
-            )
+            app.state.service_context._long_term_memories[("atri", "default")] = mock_long_term
 
             response = await client.delete("/api/data/characters/atri/long-term-memory")
 

--- a/tests/routes/test_data.py
+++ b/tests/routes/test_data.py
@@ -25,12 +25,13 @@ def _test_config(tmp_path: Path) -> dict[str, Any]:
     return config
 
 
-def _make_memory_manager(config: dict[str, Any]) -> MemoryManager:
+def _make_memory_manager(config: dict[str, Any], chat_id: str = "chat-a") -> MemoryManager:
     return MemoryManager(
         config["memory"],
         lambda _role: AsyncMock(),
         character="atri",
         user_id="default",
+        chat_id=chat_id,
         long_term=None,
     )
 
@@ -44,8 +45,10 @@ async def test_clear_short_term_memory_deletes_user_scoped_file_and_hot_cache(
 
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         async with app.router.lifespan_context(app):
-            manager = _make_memory_manager(config)
-            app.state.service_context._agents[("atri", "default")] = SimpleNamespace(
+            await app.state.storage.create_chat("default", "atri", "chat-a")
+            chat_id = (await app.state.storage.list_chats("default", "atri"))[0]["id"]
+            manager = _make_memory_manager(config, chat_id)
+            app.state.service_context._agents[("atri", "default", chat_id)] = SimpleNamespace(
                 memory_manager=manager
             )
             assert manager.short_term_store is not None
@@ -62,11 +65,14 @@ async def test_clear_short_term_memory_deletes_user_scoped_file_and_hot_cache(
             manager.short_term_store.save(manager.state)
             assert manager.short_term_store.path.is_file()
 
-            response = await client.delete("/api/data/characters/atri/short-term-memory")
+            response = await client.delete(
+                f"/api/data/characters/atri/chats/{chat_id}/short-term-memory"
+            )
 
             assert response.status_code == 200
             data = response.json()
             assert data["target"] == "short_term_memory"
+            assert data["chat_id"] == chat_id
             assert data["details"]["cache_reset"] is True
             assert not manager.short_term_store.path.exists()
             assert manager.state["total_rounds"] == 0
@@ -96,11 +102,22 @@ async def test_clear_short_term_memory_migrates_legacy_file_before_delete(tmp_pa
     app = create_app(config)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         async with app.router.lifespan_context(app):
-            response = await client.delete("/api/data/characters/atri/short-term-memory")
+            await app.state.storage.create_chat("default", "atri", "chat-a")
+            chat_id = (await app.state.storage.list_chats("default", "atri"))[0]["id"]
+            response = await client.delete(
+                f"/api/data/characters/atri/chats/{chat_id}/short-term-memory"
+            )
 
     assert response.status_code == 200
-    user_scoped_path = characters_root / "default" / "atri" / "short_term_memory.json"
-    assert not user_scoped_path.exists()
+    chat_scoped_path = (
+        characters_root
+        / "default"
+        / "atri"
+        / "chats"
+        / chat_id
+        / "short_term_memory.json"
+    )
+    assert not chat_scoped_path.exists()
     assert (legacy_dir / "short_term_memory.json").is_file()
     assert (characters_root / "default" / "atri" / ".legacy_migrated").is_file()
 
@@ -127,10 +144,21 @@ async def test_clear_short_term_memory_does_not_restore_previously_migrated_lega
     app = create_app(config)
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         async with app.router.lifespan_context(app):
-            response = await client.delete("/api/data/characters/atri/short-term-memory")
+            await app.state.storage.create_chat("default", "atri", "chat-a")
+            chat_id = (await app.state.storage.list_chats("default", "atri"))[0]["id"]
+            response = await client.delete(
+                f"/api/data/characters/atri/chats/{chat_id}/short-term-memory"
+            )
             assert response.status_code == 200
 
-            new_manager = _make_memory_manager(config)
+            new_manager = MemoryManager(
+                config["memory"],
+                lambda _role: AsyncMock(),
+                character="atri",
+                user_id="default",
+                chat_id=chat_id,
+                long_term=None,
+            )
 
     assert new_manager.short_term_store is not None
     assert not new_manager.short_term_store.path.exists()
@@ -149,7 +177,7 @@ async def test_clear_long_term_memory_submits_mem0_delete(tmp_path: Path) -> Non
                 "event_id": "evt-test",
             }
             mock_long_term.close = lambda: None
-            app.state.service_context._agents[("atri", "default")] = SimpleNamespace(
+            app.state.service_context._agents[("atri", "default", "chat-a")] = SimpleNamespace(
                 memory_manager=SimpleNamespace(long_term=mock_long_term)
             )
 

--- a/tests/storage/test_json_storage.py
+++ b/tests/storage/test_json_storage.py
@@ -109,6 +109,28 @@ async def test_get_chat_for_user_does_not_cross_user_boundary(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_get_chat_for_user_character_does_not_cross_character_boundary(tmp_path):
+    """Character-scoped lookup should only read one character index."""
+    storage = JSONChatStorage(base_path=str(tmp_path))
+    created = await storage.create_chat("user1", "atri", "Test")
+    await storage.create_chat("user1", "other", "Other")
+
+    assert await storage.get_chat_for_user_character("user1", "atri", created["id"]) is not None
+    assert await storage.get_chat_for_user_character("user1", "other", created["id"]) is None
+
+
+@pytest.mark.asyncio
+async def test_get_chat_for_user_character_rejects_unsafe_path_components(tmp_path):
+    """Character-scoped lookup should reject traversal before touching paths."""
+    storage = JSONChatStorage(base_path=str(tmp_path))
+
+    with pytest.raises(ValueError, match="Invalid"):
+        await storage.get_chat_for_user_character("user1", "atri", "../outside")
+    with pytest.raises(ValueError, match="Invalid"):
+        await storage.get_chat_for_user_character("user1", "../atri", "chat-a")
+
+
+@pytest.mark.asyncio
 async def test_update_chat_modifies_title(tmp_path):
     """Test update_chat changes title and updates updated_at."""
     storage = JSONChatStorage(base_path=str(tmp_path))

--- a/tests/test_service_context.py
+++ b/tests/test_service_context.py
@@ -285,6 +285,30 @@ def test_agent_builds_when_safe_build_long_term_returns_none(
     assert agent.memory_manager.long_term is None
 
 
+def test_long_term_failure_is_not_cached(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    long_term = _make_long_term_mock()
+    calls = 0
+
+    def _fake_safe_build_long_term(mem0_config: dict[str, Any]) -> MagicMock | None:
+        nonlocal calls
+        calls += 1
+        return None if calls == 1 else long_term
+
+    _install_stubs(monkeypatch, long_term=None)
+    monkeypatch.setattr("src.service_context._safe_build_long_term", _fake_safe_build_long_term)
+    ctx = ServiceContext(_make_config(tmp_path))
+
+    first = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    second = ctx.get_or_create_agent("atri", "alice", "chat-b")
+
+    assert first.memory_manager.long_term is None
+    assert second.memory_manager.long_term is long_term
+    assert ctx.get_cached_long_term_memory("atri", "alice") is long_term
+    assert calls == 2
+
+
 # ---------------------------------------------------------------------------
 # close_all -- graceful shutdown
 # close_all——优雅关闭

--- a/tests/test_service_context.py
+++ b/tests/test_service_context.py
@@ -105,9 +105,9 @@ def _make_config(characters_dir: Path) -> dict[str, Any]:
             "short_term": {
                 "snip": {"filler_words": []},
                 "collapse": {
-                    "trigger_rounds": 26,
+                    "trigger_rounds": 20,
                     "compress_rounds": 20,
-                    "keep_recent_rounds": 6,
+                    "keep_recent_rounds": 20,
                 },
                 "super_compact": {"trigger_blocks": 4},
                 "compressor": {"l3_role": "l3_compress", "l4_role": "l4_compact"},
@@ -177,11 +177,26 @@ def test_same_key_returns_same_instance(tmp_path: Path, monkeypatch: pytest.Monk
     _install_stubs(monkeypatch)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    first = ctx.get_or_create_agent("atri", "alice")
-    second = ctx.get_or_create_agent("atri", "alice")
+    first = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    second = ctx.get_or_create_agent("atri", "alice", "chat-a")
 
     assert first is second
     assert isinstance(first, ChatAgent)
+
+
+def test_same_character_user_different_chat_yields_distinct_instances(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _install_stubs(monkeypatch)
+    ctx = ServiceContext(_make_config(tmp_path))
+
+    chat_a = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    chat_b = ctx.get_or_create_agent("atri", "alice", "chat-b")
+
+    assert chat_a is not chat_b
+    assert chat_a.memory_manager.chat_id == "chat-a"
+    assert chat_b.memory_manager.chat_id == "chat-b"
+    assert chat_a.memory_manager.character_dir != chat_b.memory_manager.character_dir
 
 
 def test_different_character_id_yields_distinct_instances(
@@ -195,8 +210,8 @@ def test_different_character_id_yields_distinct_instances(
     _install_stubs(monkeypatch)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    atri = ctx.get_or_create_agent("atri", "alice")
-    shizuku = ctx.get_or_create_agent("shizuku", "alice")
+    atri = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    shizuku = ctx.get_or_create_agent("shizuku", "alice", "chat-a")
 
     assert atri is not shizuku
     assert atri.persona.character_id == "atri"
@@ -215,8 +230,8 @@ def test_same_character_different_user_yields_distinct_instances(
     _install_stubs(monkeypatch)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    alice_agent = ctx.get_or_create_agent("atri", "alice")
-    bob_agent = ctx.get_or_create_agent("atri", "bob")
+    alice_agent = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    bob_agent = ctx.get_or_create_agent("atri", "bob", "chat-a")
 
     assert alice_agent is not bob_agent
     assert alice_agent.memory_manager.user_id == "alice"
@@ -233,10 +248,11 @@ def test_memory_manager_wired_with_expected_character_and_user(
     _install_stubs(monkeypatch)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    agent = ctx.get_or_create_agent("atri", "alice")
+    agent = ctx.get_or_create_agent("atri", "alice", "chat-a")
 
     assert agent.memory_manager.character == "atri"
     assert agent.memory_manager.user_id == "alice"
+    assert agent.memory_manager.chat_id == "chat-a"
 
 
 def test_agent_builds_when_safe_build_long_term_returns_none(
@@ -249,7 +265,7 @@ def test_agent_builds_when_safe_build_long_term_returns_none(
     _install_stubs(monkeypatch, long_term=None)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    agent = ctx.get_or_create_agent("atri", "alice")
+    agent = ctx.get_or_create_agent("atri", "alice", "chat-a")
 
     assert agent.memory_manager.long_term is None
 
@@ -273,9 +289,9 @@ async def test_close_all_awaits_close_session_on_every_agent(
     ctx = ServiceContext(_make_config(tmp_path))
 
     agents = [
-        ctx.get_or_create_agent("atri", "alice"),
-        ctx.get_or_create_agent("atri", "bob"),
-        ctx.get_or_create_agent("shizuku", "alice"),
+        ctx.get_or_create_agent("atri", "alice", "chat-a"),
+        ctx.get_or_create_agent("atri", "bob", "chat-a"),
+        ctx.get_or_create_agent("shizuku", "alice", "chat-a"),
     ]
     for agent in agents:
         agent.memory_manager.close_session = AsyncMock()
@@ -299,7 +315,7 @@ async def test_close_all_calls_long_term_close_when_present(
     ctx = ServiceContext(_make_config(tmp_path))
 
     for cid in ("atri", "shizuku"):
-        agent = ctx.get_or_create_agent(cid, "alice")
+        agent = ctx.get_or_create_agent(cid, "alice", "chat-a")
         agent.memory_manager.close_session = AsyncMock()
 
     await ctx.close_all()
@@ -320,8 +336,8 @@ async def test_close_all_tolerates_close_session_raising(
     _install_stubs(monkeypatch, long_term=long_term)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    a1 = ctx.get_or_create_agent("atri", "alice")
-    a2 = ctx.get_or_create_agent("atri", "bob")
+    a1 = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    a2 = ctx.get_or_create_agent("atri", "bob", "chat-a")
     a1.memory_manager.close_session = AsyncMock(side_effect=RuntimeError("boom"))
     a2.memory_manager.close_session = AsyncMock()
 
@@ -347,8 +363,8 @@ async def test_close_all_tolerates_long_term_close_raising(
     _install_stubs(monkeypatch, long_term=long_term)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    a1 = ctx.get_or_create_agent("atri", "alice")
-    a2 = ctx.get_or_create_agent("atri", "bob")
+    a1 = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    a2 = ctx.get_or_create_agent("atri", "bob", "chat-a")
     a1.memory_manager.close_session = AsyncMock()
     a2.memory_manager.close_session = AsyncMock()
 
@@ -373,7 +389,7 @@ async def test_close_all_skips_long_term_close_when_none(
     _install_stubs(monkeypatch, long_term=None)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    agent = ctx.get_or_create_agent("atri", "alice")
+    agent = ctx.get_or_create_agent("atri", "alice", "chat-a")
     agent.memory_manager.close_session = AsyncMock()
 
     await ctx.close_all()

--- a/tests/test_service_context.py
+++ b/tests/test_service_context.py
@@ -199,6 +199,21 @@ def test_same_character_user_different_chat_yields_distinct_instances(
     assert chat_a.memory_manager.character_dir != chat_b.memory_manager.character_dir
 
 
+def test_same_character_user_different_chat_shares_long_term(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    long_term = _make_long_term_mock()
+    _install_stubs(monkeypatch, long_term=long_term)
+    ctx = ServiceContext(_make_config(tmp_path))
+
+    chat_a = ctx.get_or_create_agent("atri", "alice", "chat-a")
+    chat_b = ctx.get_or_create_agent("atri", "alice", "chat-b")
+
+    assert chat_a.memory_manager.long_term is long_term
+    assert chat_b.memory_manager.long_term is long_term
+    assert ctx.get_cached_long_term_memory("atri", "alice") is long_term
+
+
 def test_different_character_id_yields_distinct_instances(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -306,21 +321,21 @@ async def test_close_all_awaits_close_session_on_every_agent(
 async def test_close_all_calls_long_term_close_when_present(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """long_term.close() is called once per agent whose long_term is set.
+    """long_term.close() is called once per user/character long-term handle.
 
-    每个持有 long_term 的 agent 触发一次 long_term.close()。
+    每个 user/character 长期记忆句柄触发一次 long_term.close()。
     """
     long_term = _make_long_term_mock()
     _install_stubs(monkeypatch, long_term=long_term)
     ctx = ServiceContext(_make_config(tmp_path))
 
-    for cid in ("atri", "shizuku"):
-        agent = ctx.get_or_create_agent(cid, "alice", "chat-a")
+    for args in (("atri", "alice", "chat-a"), ("atri", "alice", "chat-b")):
+        agent = ctx.get_or_create_agent(*args)
         agent.memory_manager.close_session = AsyncMock()
 
     await ctx.close_all()
 
-    assert long_term.close.call_count == 2
+    long_term.close.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -345,8 +360,6 @@ async def test_close_all_tolerates_close_session_raising(
 
     a1.memory_manager.close_session.assert_awaited_once()
     a2.memory_manager.close_session.assert_awaited_once()
-    # long_term.close was still attempted for both agents (per-agent try/except)
-    # 两个 agent 都尝试了 long_term.close（每个 agent 独立的 try/except）
     assert long_term.close.call_count == 2
 
 


### PR DESCRIPTION
Summary:
- scope MemoryManager short-term state by user, character, and chat id
- keep long-term memory scoped by user and character
- update /settings/data cleanup API to clear one chat's short-term memory
- update frontend submodule to the matching chat cleanup UI commit

Tests:
- uv run pytest tests/memory/test_manager.py tests/test_service_context.py tests/routes/test_data.py tests/agent/test_live_chat_agent.py tests/memory/test_live_memory.py -q
- uv run ruff check src tests/routes/test_data.py tests/memory/test_manager.py tests/test_service_context.py tests/agent/test_live_chat_agent.py tests/memory/test_live_memory.py
- uv run python -m mypy src/ --ignore-missing-imports
- frontend: npm run type-check; npm run lint; npm run build