### PR TITLE
feat: add TTS synthesis logging

### DIFF
--- a/src/routes/tts.py
+++ b/src/routes/tts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException, Request, Response, status
+from loguru import logger
 
 from src.models.tts import (
     TTSConfigResponse,
@@ -145,6 +146,14 @@ async def synthesize_text(
     service: TTSServiceDep,
 ) -> Response:
     """Synthesize text with the active or requested TTS provider."""
+
+    logger.info(
+        "TTS synth request received | provider={} | text_len={} | voice_id={} | options_keys={}",
+        payload.provider or "<active>",
+        len(payload.text.strip()),
+        payload.voice_id or "<default>",
+        sorted(payload.options.keys()) if payload.options else [],
+    )
 
     try:
         result = await service.synthesize(

--- a/src/tts/service.py
+++ b/src/tts/service.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
+
+from loguru import logger
 
 from . import providers as _providers  # noqa: F401
 from .config import TTSConfigStore
@@ -119,12 +122,48 @@ class TTSService:
 
         config = self.config_store.read()
         provider_name = provider or self._active_provider(config)
+        logger.info(
+            "TTS synthesis started | provider={} | text_len={} | voice_id={}",
+            provider_name,
+            len(text),
+            voice_id or "<default>",
+        )
+
+        started_at = time.perf_counter()
         tts = self._create_provider(config, provider_name)
         health = tts.health()
         if not health.available:
+            logger.warning(
+                "TTS provider unavailable during synthesis | provider={} | reason={}",
+                provider_name,
+                health.reason or "unknown",
+            )
             raise TTSProviderUnavailableError(health.reason or f"{provider_name} is unavailable")
 
-        audio = await tts.synthesize(text, voice_id=voice_id, **(options or {}))
+        try:
+            audio = await tts.synthesize(text, voice_id=voice_id, **(options or {}))
+        except Exception:
+            duration_ms = int((time.perf_counter() - started_at) * 1000)
+            logger.exception(
+                "TTS synthesis failed | provider={} | text_len={} | voice_id={} | duration_ms={}",
+                provider_name,
+                len(text),
+                voice_id or "<default>",
+                duration_ms,
+            )
+            raise
+
+        duration_ms = int((time.perf_counter() - started_at) * 1000)
+        logger.info(
+            "TTS synthesis completed | provider={} | text_len={} | voice_id={} "
+            "| duration_ms={} | audio_bytes={} | media_type={}",
+            provider_name,
+            len(text),
+            voice_id or "<default>",
+            duration_ms,
+            len(audio),
+            tts.media_type,
+        )
         return {
             "provider": provider_name,
             "audio": audio,


### PR DESCRIPTION
## Summary
- add backend logging for TTS synthesis request, start, success, and failure paths
- keep logs focused on provider, text length, voice id, elapsed time, and audio size
- raise frontend shared axios timeout from 10s to 12s while preserving the dedicated long TTS request timeout

## Verification
- uv run python -m mypy src/ --ignore-missing-imports
- uv run ruff check src/tts/service.py src/routes/tts.py tests/routes/test_tts.py
- uv run pytest tests/routes/test_tts.py -v
- npm run type-check
- npm run lint
- npm run build