### PR TITLE
docs: add bilingual (EN+CN) docstrings to all backend modules

### DIFF
--- a/src/agent/persona.py
+++ b/src/agent/persona.py
@@ -154,7 +154,10 @@ def _split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
 
 
 def parse_persona_text(character_id: str, text: str) -> Persona:
-    """Parse persona markdown content into a Persona instance."""
+    """Parse persona markdown content into a Persona instance.
+
+    将 persona markdown 内容解析为一个 :class:`Persona` 实例。
+    """
     meta, body = _split_frontmatter(text)
 
     name = meta.get("name", character_id)
@@ -179,7 +182,10 @@ def parse_persona_text(character_id: str, text: str) -> Persona:
 
 
 def load_persona_from_path(path: Path) -> Persona:
-    """Load persona markdown from an explicit file path."""
+    """Load persona markdown from an explicit file path.
+
+    从指定的文件路径加载 persona markdown 并返回 :class:`Persona`。
+    """
     if not path.is_file():
         raise FileNotFoundError(f"Persona file not found: {path}")
 

--- a/src/asr/config.py
+++ b/src/asr/config.py
@@ -1,4 +1,14 @@
-"""ASR configuration loading and persistence."""
+"""ASR configuration loading and persistence.
+
+ASR 配置加载与持久化模块。
+
+Provides a YAML-backed configuration store with deep-merge semantics,
+environment-variable placeholder handling, and sensitive-key protection.
+
+提供基于 YAML 的配置存储，支持深度合并语义、环境变量占位符处理和敏感字段保护。
+
+Reference: docs/ASR模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -46,7 +56,15 @@ DEFAULT_ASR_CONFIG: dict[str, Any] = {
 
 
 def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
-    """Recursively merge mapping values without mutating inputs."""
+    """Recursively merge mapping values without mutating inputs.
+
+    递归合并字典值，不修改原始输入。
+
+    Nested dicts are merged key-by-key; all other values are deep-copied
+    from *override*.  Neither *base* nor *override* is modified.
+
+    嵌套字典按键逐一合并；其余值从 override 深拷贝。base 和 override 均不会被修改。
+    """
 
     result = deepcopy(base)
     for key, value in override.items():
@@ -58,7 +76,20 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
 
 
 class ASRConfigStore:
-    """Small YAML-backed configuration store for ASR settings."""
+    """Small YAML-backed configuration store for ASR settings.
+
+    轻量级 YAML 配置存储，用于管理 ASR 设置。
+
+    Reads the YAML file on construction, merges with built-in defaults,
+    and supports incremental ``update`` / full ``replace`` with optional
+    persistence.  Environment-variable placeholders (``${VAR}``) in
+    sensitive keys are preserved on disk while resolved values stay in
+    memory.
+
+    构造时读取 YAML 文件，与内置默认值合并，支持增量 update / 全量 replace
+    以及可选的持久化。敏感键中的环境变量占位符（``${VAR}``）在磁盘上保留，
+    而解析后的值保留在内存中。
+    """
 
     def __init__(
         self,
@@ -66,6 +97,17 @@ class ASRConfigStore:
         *,
         path: Path | None = None,
     ) -> None:
+        """Initialise the config store.
+
+        初始化配置存储。
+
+        Reads the YAML file at *path* (or the default location) and merges
+        it with ``DEFAULT_ASR_CONFIG``.  If *initial_config* is provided it
+        takes highest priority.
+
+        读取 path 指定的 YAML 文件（或默认位置），与 DEFAULT_ASR_CONFIG 合并。
+        若提供 initial_config，则其优先级最高。
+        """
         self.path = path or DEFAULT_ASR_CONFIG_PATH
         raw_config = self._read_raw_config()
         source_config = raw_config if raw_config is not None else initial_config or {}
@@ -75,12 +117,25 @@ class ASRConfigStore:
             self._config = deep_merge(self._config, initial_config)
 
     def read(self) -> dict[str, Any]:
-        """Return a defensive copy of the current ASR config."""
+        """Return a defensive copy of the current ASR config.
+
+        返回当前 ASR 配置的防御性副本。
+        """
 
         return deepcopy(self._config)
 
     def update(self, patch: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
-        """Merge a partial config update and persist it by default."""
+        """Merge a partial config update and persist it by default.
+
+        合并部分配置更新，默认持久化到磁盘。
+
+        Refreshes from disk first (when *persist* is ``True``) to avoid
+        overwriting concurrent edits, then deep-merges *patch* into both
+        the runtime and persisted config layers.
+
+        当 persist 为 True 时先从磁盘刷新以避免覆盖并发编辑，
+        然后将 patch 深度合并到运行时和持久化配置层。
+        """
 
         had_file = self.path.is_file()
         if persist:
@@ -92,7 +147,16 @@ class ASRConfigStore:
         return self.read()
 
     def replace(self, config: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
-        """Replace the current config after applying defaults."""
+        """Replace the current config after applying defaults.
+
+        应用默认值后替换当前配置。
+
+        Unlike ``update``, this discards all existing keys and starts
+        fresh from ``DEFAULT_ASR_CONFIG`` merged with *config*.
+
+        与 update 不同，此方法丢弃所有现有键，以 DEFAULT_ASR_CONFIG
+        与 config 合并后的结果作为全新配置。
+        """
 
         self._config = deep_merge(DEFAULT_ASR_CONFIG, config)
         self._persist_config = deepcopy(config)
@@ -101,7 +165,10 @@ class ASRConfigStore:
         return self.read()
 
     def save(self) -> None:
-        """Persist current values without reformatting the YAML document."""
+        """Persist current values without reformatting the YAML document.
+
+        持久化当前配置值，不重新格式化 YAML 文档。
+        """
 
         self._save_patch(self._persist_config)
 

--- a/src/asr/exceptions.py
+++ b/src/asr/exceptions.py
@@ -1,19 +1,61 @@
-"""ASR-specific exception hierarchy."""
+"""ASR-specific exception hierarchy.
+
+ASR 异常层次结构模块。
+
+Defines the exception classes used throughout the ASR subsystem,
+organised in a hierarchy rooted at ``ASRError``.
+
+定义 ASR 子系统使用的异常类，以 ``ASRError`` 为根组织层次结构。
+
+Reference: docs/ASR模块设计文档.md
+"""
 
 from __future__ import annotations
 
 
 class ASRError(Exception):
-    """Base exception for ASR operations."""
+    """Base exception for ASR operations.
+
+    ASR 操作的基础异常。
+
+    All ASR-specific exceptions inherit from this class so callers can
+    catch a single base type for any ASR-related failure.
+
+    所有 ASR 特定异常均继承此类，调用方可以捕获单一基类来处理所有 ASR 相关故障。
+    """
 
 
 class ASRConfigError(ASRError):
-    """Raised when ASR configuration is invalid."""
+    """Raised when ASR configuration is invalid.
+
+    当 ASR 配置无效时抛出。
+
+    Examples include missing required fields, referencing an unknown
+    provider, or providing values of the wrong type.
+
+    示例包括缺少必填字段、引用未知提供商或提供错误类型的值。
+    """
 
 
 class ASRProviderUnavailableError(ASRError):
-    """Raised when a provider cannot run because dependencies or config are missing."""
+    """Raised when a provider cannot run because dependencies or config are missing.
+
+    当提供商因缺少依赖或配置而无法运行时抛出。
+
+    Typically surfaced by ``health()`` checks or when attempting to
+    instantiate a provider whose Python package is not installed.
+
+    通常由 ``health()`` 检查触发，或在尝试实例化未安装 Python 包的提供商时抛出。
+    """
 
 
 class ASRTranscriptionError(ASRError):
-    """Raised when transcription fails after a provider was selected."""
+    """Raised when transcription fails after a provider was selected.
+
+    当提供商已选定但转录失败时抛出。
+
+    Covers errors such as empty audio input, unsupported sample rates,
+    invalid WAV headers, or runtime failures inside the ASR model.
+
+    涵盖的错误包括空音频输入、不支持的采样率、无效的 WAV 头或 ASR 模型内部运行时故障。
+    """

--- a/src/asr/factory.py
+++ b/src/asr/factory.py
@@ -1,4 +1,14 @@
-"""Decorator-based ASR provider registry."""
+"""Decorator-based ASR provider registry.
+
+基于装饰器的 ASR 提供商注册表模块。
+
+Provides a class-level registry that maps provider names to their
+implementations, along with static metadata for each provider.
+
+提供类级别的注册表，将提供商名称映射到其实现，以及每个提供商的静态元数据。
+
+Reference: docs/ASR模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -11,7 +21,15 @@ from .interface import ASRInterface
 
 @dataclass(frozen=True)
 class ASRProviderMetadata:
-    """Static metadata shown in provider list responses."""
+    """Static metadata shown in provider list responses.
+
+    在提供商列表响应中显示的静态元数据。
+
+    Carries display information and capability flags for a single ASR
+    provider.  Instances are frozen (immutable) after creation.
+
+    携带单个 ASR 提供商的展示信息和能力标志。实例创建后为冻结（不可变）状态。
+    """
 
     name: str
     display_name: str
@@ -22,7 +40,17 @@ class ASRProviderMetadata:
 
 
 class ASRFactory:
-    """Class-scoped registry mapping provider name to provider class."""
+    """Class-scoped registry mapping provider name to provider class.
+
+    类级别的注册表，将提供商名称映射到提供商类。
+
+    Provider classes register themselves via the ``@ASRFactory.register``
+    decorator.  The factory can then instantiate providers by name and
+    query available providers and their metadata.
+
+    提供商类通过 ``@ASRFactory.register`` 装饰器自行注册。工厂随后可按名称
+    实例化提供商，并查询可用提供商及其元数据。
+    """
 
     _registry: dict[str, type[ASRInterface]] = {}
     _metadata: dict[str, ASRProviderMetadata] = {}
@@ -34,7 +62,17 @@ class ASRFactory:
         *,
         metadata: ASRProviderMetadata,
     ) -> Callable[[type[ASRInterface]], type[ASRInterface]]:
-        """Return a decorator that registers a provider class."""
+        """Return a decorator that registers a provider class.
+
+        返回一个装饰器，用于注册提供商类。
+
+        The decorated class is stored in the internal registry under
+        *name* and its ``provider_name`` / capability flags are set
+        from *metadata*.
+
+        被装饰的类以 name 为键存入内部注册表，其 ``provider_name`` 和能力标志
+        从 metadata 中设置。
+        """
 
         def wrapper(provider_class: type[ASRInterface]) -> type[ASRInterface]:
             provider_class.provider_name = name
@@ -48,7 +86,14 @@ class ASRFactory:
 
     @classmethod
     def create(cls, name: str, **kwargs: Any) -> ASRInterface:
-        """Instantiate a registered provider by name."""
+        """Instantiate a registered provider by name.
+
+        按名称实例化已注册的提供商。
+
+        Raises ``ValueError`` if *name* is not found in the registry.
+
+        若 name 不在注册表中，则抛出 ``ValueError``。
+        """
 
         if name not in cls._registry:
             available = sorted(cls._registry.keys())
@@ -57,13 +102,24 @@ class ASRFactory:
 
     @classmethod
     def available(cls) -> list[str]:
-        """Return sorted registered provider names."""
+        """Return sorted registered provider names.
+
+        返回已注册提供商名称的排序列表。
+        """
 
         return sorted(cls._registry.keys())
 
     @classmethod
     def metadata(cls, name: str) -> ASRProviderMetadata:
-        """Return static metadata for a registered provider."""
+        """Return static metadata for a registered provider.
+
+        返回已注册提供商的静态元数据。
+
+        Raises ``ValueError`` if *name* is not found in the metadata
+        registry.
+
+        若 name 不在元数据注册表中，则抛出 ``ValueError``。
+        """
 
         if name not in cls._metadata:
             available = sorted(cls._metadata.keys())

--- a/src/asr/interface.py
+++ b/src/asr/interface.py
@@ -1,8 +1,15 @@
 """ASR provider interface.
 
+ASR 提供商接口模块。
+
 The core contract mirrors Open-LLM-VTuber's ASR flow: local providers
 transcribe 16 kHz, mono, 16-bit PCM-style audio represented as a numeric
 array, and the async method delegates sync model work to a worker thread.
+
+核心契约镜像 Open-LLM-VTuber 的 ASR 流程：本地提供商转录 16 kHz、单声道、
+16 位 PCM 风格的数字数组音频，异步方法将同步模型工作委托给工作线程。
+
+Reference: docs/ASR模块设计文档.md
 """
 
 from __future__ import annotations
@@ -19,14 +26,34 @@ from .exceptions import ASRProviderUnavailableError, ASRTranscriptionError
 
 @dataclass(frozen=True)
 class ASRHealth:
-    """Provider availability state."""
+    """Provider availability state.
+
+    提供商可用性状态。
+
+    Immutable data class returned by ``ASRInterface.health()`` to
+    indicate whether a provider is ready to accept transcription
+    requests.
+
+    由 ``ASRInterface.health()`` 返回的不可变数据类，用于指示提供商是否准备好
+    接受转录请求。
+    """
 
     available: bool
     reason: str | None = None
 
 
 class ASRInterface(ABC):
-    """Base interface for all ASR providers."""
+    """Base interface for all ASR providers.
+
+    所有 ASR 提供商的基础接口。
+
+    Subclasses must implement at least ``transcribe_np``.  The async
+    wrappers delegate to a thread pool by default so providers only
+    need to supply synchronous logic.
+
+    子类必须至少实现 ``transcribe_np``。异步包装器默认委托给线程池，
+    因此提供商只需提供同步逻辑。
+    """
 
     SAMPLE_RATE = 16000
     NUM_CHANNELS = 1
@@ -40,14 +67,29 @@ class ASRInterface(ABC):
         self.config = dict(config)
 
     async def async_transcribe_np(self, audio: Any) -> str:
-        """Transcribe an OLV-style numeric audio array asynchronously."""
+        """Transcribe an OLV-style numeric audio array asynchronously.
+
+        异步转录 OLV 风格的数字音频数组。
+
+        Delegates to ``transcribe_np`` via ``asyncio.to_thread``.
+
+        通过 ``asyncio.to_thread`` 委托给 ``transcribe_np``。
+        """
 
         audio = self._ensure_float32_array(audio)
         return await asyncio.to_thread(self.transcribe_np, audio)
 
     @abstractmethod
     def transcribe_np(self, audio: Any) -> str:
-        """Transcribe a 16 kHz mono float32 audio array."""
+        """Transcribe a 16 kHz mono float32 audio array.
+
+        转录 16 kHz 单声道 float32 音频数组。
+
+        This is the core synchronous contract that every local provider
+        must implement.
+
+        这是每个本地提供商必须实现的核心同步契约。
+        """
 
     async def async_transcribe_audio(
         self,
@@ -58,9 +100,14 @@ class ASRInterface(ABC):
     ) -> str:
         """Transcribe uploaded audio bytes.
 
+        转录上传的音频字节。
+
         The default path converts 16 kHz mono PCM WAV bytes into the OLV
         numeric-array contract and then calls :meth:`async_transcribe_np`.
         Providers that can decode other formats should override this method.
+
+        默认路径将 16 kHz 单声道 PCM WAV 字节转换为 OLV 数字数组格式，
+        然后调用 :meth:`async_transcribe_np`。能解码其他格式的提供商应覆盖此方法。
         """
 
         if not audio:
@@ -73,7 +120,17 @@ class ASRInterface(ABC):
         return await self.async_transcribe_np(audio_array)
 
     def health(self) -> ASRHealth:
-        """Return provider availability without doing heavyweight model work."""
+        """Return provider availability without doing heavyweight model work.
+
+        返回提供商可用性状态，不执行重量级模型加载操作。
+
+        The default implementation always returns ``available=True``.
+        Subclasses should override this to check for missing dependencies
+        or misconfigured credentials.
+
+        默认实现始终返回 ``available=True``。子类应覆盖此方法以检查缺失的依赖
+        或未正确配置的凭证。
+        """
 
         return ASRHealth(available=True)
 
@@ -98,7 +155,15 @@ class ASRInterface(ABC):
         filename: str | None = None,
         content_type: str | None = None,
     ) -> Any:
-        """Convert a PCM WAV upload into an OLV-style float32 mono array."""
+        """Convert a PCM WAV upload into an OLV-style float32 mono array.
+
+        将 PCM WAV 上传转换为 OLV 风格的 float32 单声道数组。
+
+        Supports 8-bit, 16-bit, and 32-bit WAV.  Multi-channel audio is
+        down-mixed to mono by averaging channels.
+
+        支持 8 位、16 位和 32 位 WAV。多声道音频通过取各声道平均值降混为单声道。
+        """
 
         try:
             import numpy as np
@@ -143,7 +208,15 @@ class ASRInterface(ABC):
         return np.clip(samples, -1.0, 1.0).astype(np.float32)
 
     def nparray_to_audio_file(self, audio: Any, sample_rate: int, file_path: str) -> None:
-        """Write a numeric audio array as a mono 16-bit PCM WAV file."""
+        """Write a numeric audio array as a mono 16-bit PCM WAV file.
+
+        将数字音频数组写入为单声道 16 位 PCM WAV 文件。
+
+        Values are clipped to [-1, 1] and scaled to int16 range before
+        writing.
+
+        写入前将值裁剪到 [-1, 1] 范围并缩放到 int16 范围。
+        """
 
         try:
             import numpy as np

--- a/src/asr/providers/faster_whisper.py
+++ b/src/asr/providers/faster_whisper.py
@@ -1,9 +1,17 @@
 """faster-whisper ASR provider.
 
+faster-whisper ASR 提供商模块。
+
 The numpy-array transcription path follows Open-LLM-VTuber's
 `faster_whisper_asr.py`: lazy-create `WhisperModel`, call `transcribe`
 with beam search, optional language and prompt, and concatenate segment
 text.
+
+numpy 数组转录路径遵循 Open-LLM-VTuber 的 `faster_whisper_asr.py`：
+延迟创建 `WhisperModel`，使用束搜索调用 `transcribe`，支持可选的语言和提示词，
+并拼接分段文本。
+
+Reference: docs/ASR模块设计文档.md
 """
 
 from __future__ import annotations
@@ -30,7 +38,17 @@ from src.asr.interface import ASRHealth, ASRInterface
     ),
 )
 class FasterWhisperASR(ASRInterface):
-    """Local faster-whisper provider with lazy optional dependency loading."""
+    """Local faster-whisper provider with lazy optional dependency loading.
+
+    本地 faster-whisper 提供商，延迟加载可选依赖。
+
+    The underlying ``WhisperModel`` is created on first use so that
+    importing this module does not require the ``faster_whisper``
+    package to be installed.
+
+    底层 ``WhisperModel`` 在首次使用时创建，因此导入此模块不要求安装
+    ``faster_whisper`` 包。
+    """
 
     BEAM_SEARCH = True
 
@@ -52,6 +70,15 @@ class FasterWhisperASR(ASRInterface):
         return ASRHealth(True)
 
     def transcribe_np(self, audio: Any) -> str:
+        """Transcribe a float32 numpy audio array using faster-whisper.
+
+        使用 faster-whisper 转录 float32 numpy 音频数组。
+
+        Uses beam search and optional language/prompt settings from the
+        provider config.  Segments are concatenated into a single string.
+
+        使用束搜索和提供商配置中的可选语言/提示词设置。分段结果拼接为单个字符串。
+        """
         model = self._get_model()
         kwargs: dict[str, Any] = {
             "beam_size": 5 if self.BEAM_SEARCH else 1,
@@ -73,10 +100,15 @@ class FasterWhisperASR(ASRInterface):
     ) -> str:
         """Transcribe uploaded audio.
 
+        转录上传的音频。
+
         WAV uploads use the OLV numpy-array path. Other browser formats are
         passed to faster-whisper through a temporary file, which keeps the
         provider usable with MediaRecorder while preserving `transcribe_np`
         as the core local-provider contract.
+
+        WAV 上传使用 OLV 数组路径。其他浏览器格式通过临时文件传递给 faster-whisper，
+        使提供商可与 MediaRecorder 配合使用，同时保留 `transcribe_np` 作为核心本地契约。
         """
 
         if self._looks_like_wav(audio, filename=filename, content_type=content_type):

--- a/src/asr/providers/openai_whisper.py
+++ b/src/asr/providers/openai_whisper.py
@@ -1,4 +1,16 @@
-"""OpenAI Whisper-compatible cloud ASR provider."""
+"""OpenAI Whisper-compatible cloud ASR provider.
+
+OpenAI Whisper 兼容的云端 ASR 提供商模块。
+
+Provides cloud-based audio transcription through the OpenAI-compatible
+SDK.  Audio bytes are written to a temporary file and sent via the
+``audio.transcriptions`` API.
+
+通过 OpenAI 兼容 SDK 提供基于云端的音频转录。音频字节写入临时文件后通过
+``audio.transcriptions`` API 发送。
+
+Reference: docs/ASR模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -24,7 +36,17 @@ from src.asr.interface import ASRHealth, ASRInterface
     ),
 )
 class OpenAIWhisperASR(ASRInterface):
-    """Cloud transcription provider with lazy OpenAI client creation."""
+    """Cloud transcription provider with lazy OpenAI client creation.
+
+    云端转录提供商，延迟创建 OpenAI 客户端。
+
+    This provider does **not** support numpy-array transcription; it
+    only accepts uploaded audio bytes.  The OpenAI client is created
+    per-request to avoid holding credentials in long-lived objects.
+
+    此提供商**不**支持 numpy 数组转录；仅接受上传的音频字节。OpenAI 客户端
+    每次请求时创建，避免在长生命周期对象中持有凭证。
+    """
 
     def __init__(self, **config: Any) -> None:
         super().__init__(**config)
@@ -44,6 +66,14 @@ class OpenAIWhisperASR(ASRInterface):
         return ASRHealth(True)
 
     def transcribe_np(self, audio: Any) -> str:
+        """Not supported — cloud providers do not accept numpy arrays.
+
+        不支持 — 云端提供商不接受 numpy 数组。
+
+        Always raises ``ASRProviderUnavailableError``.
+
+        始终抛出 ``ASRProviderUnavailableError``。
+        """
         raise ASRProviderUnavailableError(
             "openai_whisper accepts uploaded audio files, not numpy arrays"
         )
@@ -55,6 +85,15 @@ class OpenAIWhisperASR(ASRInterface):
         filename: str | None = None,
         content_type: str | None = None,
     ) -> str:
+        """Transcribe uploaded audio bytes via the OpenAI API.
+
+        通过 OpenAI API 转录上传的音频字节。
+
+        Audio is written to a temporary file (preserving the original
+        extension) and sent to the ``audio.transcriptions`` endpoint.
+
+        音频写入临时文件（保留原始扩展名）并发送到 ``audio.transcriptions`` 端点。
+        """
         health = self.health()
         if not health.available:
             raise ASRProviderUnavailableError(health.reason or "openai_whisper is unavailable")

--- a/src/asr/providers/web_speech_api.py
+++ b/src/asr/providers/web_speech_api.py
@@ -1,8 +1,15 @@
 """Browser Web Speech API provider marker.
 
+浏览器 Web Speech API 提供商标记模块。
+
 The implementation follows AIRI's split: Web Speech API runs in the browser
 with live recognition, while the backend only exposes configuration and
 provider status.
+
+实现遵循 AIRI 的分离策略：Web Speech API 在浏览器中运行实时识别，
+而后端仅暴露配置和提供商状态。
+
+Reference: docs/ASR模块设计文档.md
 """
 
 from __future__ import annotations
@@ -26,7 +33,17 @@ from src.asr.interface import ASRHealth, ASRInterface
     ),
 )
 class WebSpeechAPIASR(ASRInterface):
-    """Configuration-only provider for browser Web Speech API."""
+    """Configuration-only provider for browser Web Speech API.
+
+    浏览器 Web Speech API 的纯配置提供商。
+
+    Transcription runs entirely in the browser via the native Web Speech
+    API.  This backend class only stores configuration (language, mode,
+    etc.) and reports health; it does **not** accept audio uploads.
+
+    转录完全在浏览器中通过原生 Web Speech API 运行。此后端类仅存储配置
+    （语言、模式等）并报告健康状态；**不**接受音频上传。
+    """
 
     def __init__(self, **config: Any) -> None:
         super().__init__(**config)
@@ -39,6 +56,14 @@ class WebSpeechAPIASR(ASRInterface):
         return ASRHealth(True, "Browser availability is checked in the frontend")
 
     def transcribe_np(self, audio: Any) -> str:
+        """Not supported — transcription runs in the browser.
+
+        不支持 — 转录在浏览器中运行。
+
+        Always raises ``ASRProviderUnavailableError``.
+
+        始终抛出 ``ASRProviderUnavailableError``。
+        """
         raise ASRProviderUnavailableError(
             "Web Speech API runs in the browser and does not support backend audio uploads"
         )
@@ -50,6 +75,14 @@ class WebSpeechAPIASR(ASRInterface):
         filename: str | None = None,
         content_type: str | None = None,
     ) -> str:
+        """Not supported — transcription runs in the browser.
+
+        不支持 — 转录在浏览器中运行。
+
+        Always raises ``ASRProviderUnavailableError``.
+
+        始终抛出 ``ASRProviderUnavailableError``。
+        """
         raise ASRProviderUnavailableError(
             "Web Speech API runs in the browser and does not support backend audio uploads"
         )

--- a/src/asr/providers/whisper_cpp.py
+++ b/src/asr/providers/whisper_cpp.py
@@ -1,4 +1,16 @@
-"""whisper.cpp ASR provider via pywhispercpp."""
+"""whisper.cpp ASR provider via pywhispercpp.
+
+通过 pywhispercpp 的 whisper.cpp ASR 提供商模块。
+
+Provides local transcription using the whisper.cpp engine wrapped by
+the ``pywhispercpp`` Python package.  The model is lazily loaded on
+first use.
+
+使用 ``pywhispercpp`` Python 包封装的 whisper.cpp 引擎提供本地转录。
+模型在首次使用时延迟加载。
+
+Reference: docs/ASR模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -24,7 +36,17 @@ from src.asr.interface import ASRHealth, ASRInterface
     ),
 )
 class WhisperCppASR(ASRInterface):
-    """Local whisper.cpp provider with lazy optional dependency loading."""
+    """Local whisper.cpp provider with lazy optional dependency loading.
+
+    本地 whisper.cpp 提供商，延迟加载可选依赖。
+
+    The underlying ``pywhispercpp.model.Model`` is created on first
+    transcription so that importing this module does not require the
+    ``pywhispercpp`` package to be installed.
+
+    底层 ``pywhispercpp.model.Model`` 在首次转录时创建，因此导入此模块不要求
+    安装 ``pywhispercpp`` 包。
+    """
 
     def __init__(self, **config: Any) -> None:
         super().__init__(**config)
@@ -44,6 +66,15 @@ class WhisperCppASR(ASRInterface):
         return ASRHealth(True)
 
     def transcribe_np(self, audio: Any) -> str:
+        """Transcribe a float32 numpy audio array using whisper.cpp.
+
+        使用 whisper.cpp 转录 float32 numpy 音频数组。
+
+        Segments are concatenated into a single string.  An optional
+        ``initial_prompt`` is passed to guide the model.
+
+        分段结果拼接为单个字符串。可选的 ``initial_prompt`` 用于引导模型。
+        """
         model = self._get_model()
         kwargs: dict[str, Any] = {"new_segment_callback": logger.info}
         if self.prompt:

--- a/src/asr/service.py
+++ b/src/asr/service.py
@@ -1,4 +1,15 @@
-"""ASR application service."""
+"""ASR application service.
+
+ASR 应用服务模块。
+
+Orchestrates ASR configuration, provider health checks, provider
+switching, and audio transcription.  Serves as the primary entry
+point for API routes.
+
+协调 ASR 配置、提供商健康检查、提供商切换和音频转录。作为 API 路由的主要入口点。
+
+Reference: docs/ASR模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -20,18 +31,46 @@ PROVIDER_WRITE_ALLOWLISTS: dict[str, set[str]] = {
 
 
 class ASRService:
-    """Coordinate ASR config, provider health, switching, and transcription."""
+    """Coordinate ASR config, provider health, switching, and transcription.
+
+    协调 ASR 配置、提供商健康检查、切换和转录。
+
+    This is the top-level facade consumed by API route handlers.
+    It delegates configuration persistence to ``ASRConfigStore`` and
+    provider instantiation to ``ASRFactory``.
+
+    这是 API 路由处理器使用的顶层门面。它将配置持久化委托给 ``ASRConfigStore``,
+    将提供商实例化委托给 ``ASRFactory``。
+    """
 
     def __init__(self, config_store: ASRConfigStore) -> None:
         self.config_store = config_store
 
     def get_config(self) -> dict[str, Any]:
-        """Return persisted OLV-shaped ASR config."""
+        """Return persisted OLV-shaped ASR config.
+
+        返回持久化的 OLV 格式 ASR 配置。
+
+        Sensitive values (API keys, tokens) are masked before being
+        returned to the caller.
+
+        敏感值（API 密钥、令牌）在返回给调用方之前会被掩码处理。
+        """
 
         return self._public_config(self.config_store.read())
 
     def update_config(self, patch: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
-        """Merge and persist a partial OLV-shaped ASR config update."""
+        """Merge and persist a partial OLV-shaped ASR config update.
+
+        合并并持久化部分 OLV 格式 ASR 配置更新。
+
+        Masked sensitive values and read-only provider fields are
+        stripped before the patch is applied.  If the patch changes
+        ``asr_model``, the new provider is validated first.
+
+        在应用补丁之前，会剥离掩码的敏感值和只读提供商字段。
+        若补丁更改了 ``asr_model``，会先验证新提供商。
+        """
 
         patch = self._strip_masked_sensitive_values(patch)
         patch = self._strip_forbidden_provider_writes(patch)
@@ -41,13 +80,28 @@ class ASRService:
         return self.config_store.update(patch, persist=persist)
 
     def switch_provider(self, provider: str, *, persist: bool = True) -> dict[str, Any]:
-        """Switch the active ASR provider."""
+        """Switch the active ASR provider.
+
+        切换当前活跃的 ASR 提供商。
+
+        Raises ``ASRConfigError`` if *provider* is not registered.
+
+        若 provider 未注册，则抛出 ``ASRConfigError``。
+        """
 
         self._ensure_provider_registered(provider)
         return self.config_store.update({"asr_model": provider}, persist=persist)
 
     def list_providers(self) -> list[dict[str, Any]]:
-        """Return registered provider metadata plus health/config state."""
+        """Return registered provider metadata plus health/config state.
+
+        返回已注册提供商的元数据及其健康状态和配置信息。
+
+        Each entry includes display name, type, description, capability
+        flags, health status, active flag, and masked config.
+
+        每个条目包含显示名称、类型、描述、能力标志、健康状态、活跃标志和掩码配置。
+        """
 
         config = self.config_store.read()
         active_provider = self._active_provider(config)
@@ -75,7 +129,16 @@ class ASRService:
         return providers
 
     def health(self) -> dict[str, Any]:
-        """Return active and all-provider ASR health state."""
+        """Return active and all-provider ASR health state.
+
+        返回当前活跃提供商和所有提供商的 ASR 健康状态。
+
+        The response includes the active provider name, whether it is
+        available, and the full provider list with individual health
+        information.
+
+        响应包含活跃提供商名称、其是否可用，以及带有各提供商健康信息的完整列表。
+        """
 
         config = self.config_store.read()
         active_provider = self._active_provider(config)
@@ -98,7 +161,17 @@ class ASRService:
         content_type: str | None = None,
         provider: str | None = None,
     ) -> dict[str, Any]:
-        """Transcribe uploaded audio with the selected backend-capable provider."""
+        """Transcribe uploaded audio with the selected backend-capable provider.
+
+        使用选定的后端转录提供商转录上传的音频。
+
+        Validates that the chosen provider supports backend transcription
+        and is healthy before delegating.  Returns a dict containing
+        the provider name and transcribed text.
+
+        在委托之前验证所选提供商支持后端转录且健康状态正常。
+        返回包含提供商名称和转录文本的字典。
+        """
 
         config = self.config_store.read()
         provider_name = provider or self._active_provider(config)

--- a/src/auth/dependencies.py
+++ b/src/auth/dependencies.py
@@ -1,4 +1,7 @@
-"""Authentication helpers shared by HTTP routes and WebSocket handlers."""
+"""Authentication helpers shared by HTTP routes and WebSocket handlers.
+
+HTTP 路由和 WebSocket 处理器共享的认证辅助函数。
+"""
 
 from __future__ import annotations
 
@@ -23,7 +26,10 @@ def get_auth_service(app: Any) -> AuthService:
 
 
 def get_request_user_id(request: Request) -> str:
-    """Return current user id for REST routes."""
+    """Return current user id for REST routes.
+
+    返回 REST 路由的当前用户 ID。
+    """
     if hasattr(request.state, "user_id"):
         return str(request.state.user_id)
     auth_service = get_auth_service(request.app)
@@ -44,7 +50,10 @@ def get_request_user_id(request: Request) -> str:
 
 
 def get_websocket_user_id(websocket: WebSocket) -> str:
-    """Return current user id for WebSocket routes."""
+    """Return current user id for WebSocket routes.
+
+    返回 WebSocket 路由的当前用户 ID。
+    """
     auth_service = get_auth_service(websocket.app)
     if not auth_service.enabled:
         return DEFAULT_USER_ID

--- a/src/auth/exceptions.py
+++ b/src/auth/exceptions.py
@@ -1,18 +1,33 @@
-"""Authentication exception hierarchy."""
+"""Authentication exception hierarchy.
+
+认证异常层次结构。
+"""
 
 
 class AuthError(Exception):
-    """Base authentication error."""
+    """Base authentication error.
+
+    认证错误基类。
+    """
 
 
 class AuthConfigError(AuthError):
-    """Authentication configuration is missing or invalid."""
+    """Authentication configuration is missing or invalid.
+
+    认证配置缺失或无效。
+    """
 
 
 class AuthUnauthorizedError(AuthError):
-    """Request is not authenticated or the user is not allowed."""
+    """Request is not authenticated or the user is not allowed.
+
+    请求未认证或用户不在允许列表中。
+    """
 
 
 class AuthTokenError(AuthUnauthorizedError):
-    """JWT token is missing, invalid, or expired."""
+    """JWT token is missing, invalid, or expired.
+
+    JWT 令牌缺失、无效或已过期。
+    """
 

--- a/src/auth/jwt.py
+++ b/src/auth/jwt.py
@@ -1,4 +1,7 @@
-"""Small HS256 JWT implementation using the Python standard library."""
+"""Small HS256 JWT implementation using the Python standard library.
+
+基于 Python 标准库的小型 HS256 JWT 实现。
+"""
 
 from __future__ import annotations
 
@@ -29,7 +32,10 @@ def _json_dumps(data: dict[str, Any]) -> bytes:
 
 
 class JWTManager:
-    """Create and verify HS256 JWT tokens."""
+    """Create and verify HS256 JWT tokens.
+
+    创建和验证 HS256 JWT 令牌。
+    """
 
     def __init__(
         self,
@@ -56,7 +62,10 @@ class JWTManager:
         avatar_url: str | None = None,
         now: datetime | None = None,
     ) -> str:
-        """Create a signed JWT token for a GitHub username."""
+        """Create a signed JWT token for a GitHub username.
+
+        为 GitHub 用户名创建签名的 JWT 令牌。
+        """
         issued_at = now or datetime.now(UTC)
         expires_at = issued_at + timedelta(days=self.expire_days)
         payload: dict[str, Any] = {
@@ -75,7 +84,10 @@ class JWTManager:
         return f"{signing_input}.{signature}"
 
     def verify_token(self, token: str, *, now: datetime | None = None) -> dict[str, Any]:
-        """Verify a token and return its payload."""
+        """Verify a token and return its payload.
+
+        验证令牌并返回其载荷。
+        """
         parts = token.split(".")
         if len(parts) != 3:
             raise AuthTokenError("Invalid token format")

--- a/src/auth/oauth.py
+++ b/src/auth/oauth.py
@@ -1,4 +1,7 @@
-"""GitHub OAuth client."""
+"""GitHub OAuth client.
+
+GitHub OAuth 客户端。
+"""
 
 from __future__ import annotations
 
@@ -16,7 +19,10 @@ GITHUB_USER_URL = "https://api.github.com/user"
 
 @dataclass(frozen=True)
 class GitHubUser:
-    """Authenticated GitHub user profile."""
+    """Authenticated GitHub user profile.
+
+    已认证的 GitHub 用户资料。
+    """
 
     username: str
     avatar_url: str | None = None
@@ -24,7 +30,10 @@ class GitHubUser:
 
 
 class GitHubOAuth:
-    """Minimal GitHub OAuth web flow client."""
+    """Minimal GitHub OAuth web flow client.
+
+    最小化的 GitHub OAuth Web 流程客户端。
+    """
 
     def __init__(
         self,
@@ -46,6 +55,10 @@ class GitHubOAuth:
         self.scope = scope
 
     def get_authorization_url(self, state: str | None = None) -> str:
+        """Build the GitHub authorization redirect URL.
+
+        构建 GitHub 授权重定向 URL。
+        """
         query = {
             "client_id": self.client_id,
             "redirect_uri": self.callback_url,
@@ -56,6 +69,10 @@ class GitHubOAuth:
         return f"{GITHUB_AUTHORIZE_URL}?{urlencode(query)}"
 
     async def exchange_code_for_token(self, code: str) -> str:
+        """Exchange an OAuth authorization code for an access token.
+
+        将 OAuth 授权码交换为访问令牌。
+        """
         async with httpx.AsyncClient(timeout=15) as client:
             response = await client.post(
                 GITHUB_TOKEN_URL,
@@ -75,6 +92,10 @@ class GitHubOAuth:
         return access_token
 
     async def get_user_info(self, access_token: str) -> GitHubUser:
+        """Fetch the authenticated user's profile from GitHub.
+
+        从 GitHub 获取已认证用户的资料。
+        """
         async with httpx.AsyncClient(timeout=15) as client:
             response = await client.get(
                 GITHUB_USER_URL,

--- a/src/auth/service.py
+++ b/src/auth/service.py
@@ -1,4 +1,7 @@
-"""Application-level authentication service."""
+"""Application-level authentication service.
+
+应用级认证服务。
+"""
 
 from __future__ import annotations
 
@@ -14,7 +17,10 @@ from src.auth.whitelist import Whitelist
 
 @dataclass(frozen=True)
 class AuthenticatedUser:
-    """Authenticated user identity exposed to routes."""
+    """Authenticated user identity exposed to routes.
+
+    暴露给路由的已认证用户身份。
+    """
 
     username: str
     avatar_url: str | None = None
@@ -22,7 +28,10 @@ class AuthenticatedUser:
 
 
 class AuthService:
-    """Auth facade used by routes, middleware, and WebSocket handlers."""
+    """Auth facade used by routes, middleware, and WebSocket handlers.
+
+    供路由、中间件和 WebSocket 处理器使用的认证门面。
+    """
 
     def __init__(self, config: dict[str, Any]) -> None:
         self.config = config
@@ -58,15 +67,27 @@ class AuthService:
             )
 
     def create_token_for_github_user(self, user: GitHubUser) -> str:
+        """Create a JWT token for an authenticated GitHub user.
+
+        为已认证的 GitHub 用户创建 JWT 令牌。
+        """
         if not self.jwt_manager:
             raise AuthConfigError("JWT manager is not configured")
         return self.jwt_manager.create_token(user.username, avatar_url=user.avatar_url)
 
     def require_allowed_user(self, user: GitHubUser) -> None:
+        """Raise if the user is not on the whitelist.
+
+        若用户不在白名单中则抛出异常。
+        """
         if not self.whitelist.is_allowed(user.username):
             raise AuthUnauthorizedError(f"GitHub user '{user.username}' is not whitelisted")
 
     def authenticate_bearer_token(self, authorization: str | None) -> AuthenticatedUser:
+        """Authenticate a request via Bearer token.
+
+        通过 Bearer 令牌认证请求。
+        """
         if not self.enabled:
             return AuthenticatedUser(username="default")
         if not authorization or not authorization.startswith("Bearer "):
@@ -79,6 +100,10 @@ class AuthService:
         authorization: str | None,
         session_token: str | None,
     ) -> AuthenticatedUser:
+        """Authenticate via session cookie or Bearer token (cookie takes priority).
+
+        通过会话 Cookie 或 Bearer 令牌认证（Cookie 优先）。
+        """
         if not self.enabled:
             return AuthenticatedUser(username="default")
         if session_token:
@@ -88,6 +113,10 @@ class AuthService:
         raise AuthTokenError("Missing session cookie")
 
     def authenticate_token(self, token: str | None) -> AuthenticatedUser:
+        """Verify a JWT token and return the authenticated user.
+
+        验证 JWT 令牌并返回已认证的用户。
+        """
         if not self.enabled:
             return AuthenticatedUser(username="default")
         if not token:

--- a/src/auth/session.py
+++ b/src/auth/session.py
@@ -1,4 +1,7 @@
-"""Shared session-cookie constants for authentication."""
+"""Shared session-cookie constants for authentication.
+
+认证共享的会话 Cookie 常量。
+"""
 
 from typing import Literal
 

--- a/src/auth/whitelist.py
+++ b/src/auth/whitelist.py
@@ -1,10 +1,16 @@
-"""GitHub username whitelist checks."""
+"""GitHub username whitelist checks.
+
+GitHub 用户名白名单检查。
+"""
 
 from __future__ import annotations
 
 
 class Whitelist:
-    """Case-insensitive GitHub username whitelist."""
+    """Case-insensitive GitHub username whitelist.
+
+    不区分大小写的 GitHub 用户名白名单。
+    """
 
     def __init__(self, users: list[str] | None = None) -> None:
         self._users = {user.casefold() for user in users or [] if user.strip()}

--- a/src/memory/long_term.py
+++ b/src/memory/long_term.py
@@ -446,7 +446,10 @@ class LongTermMemory:
         return results
 
     def invalidate_search_cache(self, user_id: str, agent_id: str) -> None:
-        """Drop cached search results for one user/agent scope."""
+        """Drop cached search results for one user/agent scope.
+
+        丢弃某个 user/agent 作用域的缓存搜索结果。
+        """
         if self._search_cache is not None:
             self._search_cache.invalidate_scope(user_id=user_id, agent_id=agent_id)
 
@@ -461,6 +464,11 @@ class LongTermMemory:
         Hosted mem0 may return an asynchronous "delete in progress" response;
         callers should surface that as a submitted cleanup operation instead
         of assuming immediate dashboard consistency.
+
+        删除指定 mem0 作用域的长期记忆。
+
+        托管版 mem0 可能返回异步的"删除中"响应；调用方应将其呈现为已提交的
+        清理操作，而非假设仪表盘会立即一致。
         """
 
         kwargs: dict[str, str] = {"user_id": user_id, "agent_id": agent_id}

--- a/src/memory/manager.py
+++ b/src/memory/manager.py
@@ -114,6 +114,13 @@ def resolve_user_character_dir(
     mem0's ``user_id`` / ``agent_id`` scope. On first access, copy legacy
     files into the current user's directory and keep the legacy files as a
     fallback backup.
+
+    返回某个角色的用户级本地记忆目录。
+
+    旧版部署将短期记忆存储在 ``{characters_dir}/{character}``。新路径为
+    ``{characters_dir}/{user_id}/{character}``，与聊天存储和 mem0 的
+    ``user_id`` / ``agent_id`` 作用域保持一致。首次访问时，将旧文件复制到
+    当前用户目录，并保留旧文件作为回退备份。
     """
 
     safe_user_id = _validate_path_component("user_id", user_id)
@@ -126,7 +133,10 @@ def resolve_user_character_dir(
 
 
 def legacy_character_dir(memory_config: dict[str, Any], character: str) -> Path:
-    """Return the pre-user-scope memory directory for ``character``."""
+    """Return the pre-user-scope memory directory for ``character``.
+
+    返回 ``character`` 在用户作用域之前的记忆目录。
+    """
 
     safe_character = _validate_path_component("character", character)
     chars_root = Path(memory_config.get("storage", {}).get("characters_dir", "./data/characters"))
@@ -182,7 +192,10 @@ def resolve_user_character_chat_dir(
     *,
     migrate_legacy: bool = True,
 ) -> Path:
-    """Return the chat-scoped local memory directory for a character chat."""
+    """Return the chat-scoped local memory directory for a character chat.
+
+    返回某次角色聊天的聊天级本地记忆目录。
+    """
 
     safe_chat_id = _validate_path_component("chat_id", chat_id)
     character_dir = resolve_user_character_dir(
@@ -484,6 +497,11 @@ class MemoryManager:
         The manager remains usable after this call: the active session id is
         preserved when present, and the next round starts with an empty
         ``short_term_memory`` skeleton instead of restoring old context.
+
+        热清除内存中的短期状态并删除其文件。
+
+        调用后管理器仍可继续使用：活动会话 ID（若存在）会被保留，下一轮
+        将以空的 ``short_term_memory`` 骨架开始，而非恢复旧上下文。
         """
 
         session_id = self._active_session_id or _new_session_id()

--- a/src/memory/retrieval_policy.py
+++ b/src/memory/retrieval_policy.py
@@ -3,6 +3,13 @@
 This module decides whether a chat turn should call ``mem0.search`` before
 building the LLM context. It is intentionally pure so quota-saving behavior can
 be tested without touching mem0.
+
+长期记忆检索策略。
+
+本模块决定某次聊天轮次是否应在组装 LLM 上下文前调用 ``mem0.search``。
+设计为纯函数，使配额节省行为可在不触及 mem0 的情况下进行测试。
+
+Reference: docs/记忆系统设计讨论.md §8.1–§8.4
 """
 
 from __future__ import annotations
@@ -34,12 +41,22 @@ def _parse_trigger_keywords(value: Any) -> tuple[str, ...]:
 
 @dataclass(frozen=True)
 class RetrievalDecision:
+    """Result of a retrieval policy evaluation.
+
+    检索策略评估的结果。
+    """
+
     should_search: bool
     reason: str
 
 
 @dataclass(frozen=True)
 class LongTermRetrievalPolicy:
+    """Configuration-driven policy that decides when to call mem0.search.
+
+    由配置驱动的策略，决定何时调用 mem0.search。
+    """
+
     enabled: bool = True
     policy: str = "always"
     interval_turns: int = 10
@@ -48,6 +65,10 @@ class LongTermRetrievalPolicy:
 
     @classmethod
     def from_mem0_config(cls, mem0_config: dict[str, Any]) -> LongTermRetrievalPolicy:
+        """Build a policy instance from the ``mem0`` section of config yaml.
+
+        从配置 yaml 的 ``mem0`` 部分构建策略实例。
+        """
         retrieval_cfg = mem0_config.get("retrieval")
         if not isinstance(retrieval_cfg, dict):
             return cls()
@@ -73,6 +94,10 @@ class LongTermRetrievalPolicy:
         current_round: int,
         last_search_round: int | None,
     ) -> RetrievalDecision:
+        """Evaluate whether the current turn should trigger a long-term search.
+
+        评估当前轮次是否应触发长期记忆搜索。
+        """
         text = " ".join(query.strip().split())
         if not self.enabled:
             return RetrievalDecision(False, "disabled")

--- a/src/memory/search_cache.py
+++ b/src/memory/search_cache.py
@@ -1,4 +1,9 @@
-"""Small in-process cache for long-term memory search results."""
+"""Small in-process cache for long-term memory search results.
+
+长期记忆搜索结果的进程内小缓存。
+
+Reference: docs/记忆系统设计讨论.md §8.3
+"""
 
 from __future__ import annotations
 
@@ -16,6 +21,11 @@ def normalize_search_query(query: str) -> str:
 
 @dataclass(frozen=True)
 class SearchCacheKey:
+    """Composite cache key for a single mem0 search query.
+
+    单次 mem0 搜索查询的组合缓存键。
+    """
+
     user_id: str
     agent_id: str
     query: str
@@ -30,7 +40,10 @@ class _SearchCacheEntry:
 
 
 class SearchCache:
-    """TTL + LRU cache for repeated mem0.search calls in one process."""
+    """TTL + LRU cache for repeated mem0.search calls in one process.
+
+    单进程内用于重复 mem0.search 调用的 TTL + LRU 缓存。
+    """
 
     def __init__(
         self,
@@ -53,6 +66,10 @@ class SearchCache:
         limit: int,
         threshold: float,
     ) -> SearchCacheKey:
+        """Build a normalised cache key from search parameters.
+
+        从搜索参数构建标准化的缓存键。
+        """
         return SearchCacheKey(
             user_id=user_id,
             agent_id=agent_id,
@@ -62,6 +79,10 @@ class SearchCache:
         )
 
     def get(self, key: SearchCacheKey) -> list[dict[str, Any]] | None:
+        """Return cached value if present and not expired, else None.
+
+        若缓存存在且未过期则返回缓存值，否则返回 None。
+        """
         entry = self._entries.get(key)
         if entry is None:
             return None
@@ -72,6 +93,10 @@ class SearchCache:
         return deepcopy(entry.value)
 
     def set(self, key: SearchCacheKey, value: list[dict[str, Any]]) -> None:
+        """Store a search result, evicting the oldest entry if at capacity.
+
+        存储搜索结果，若达到容量上限则淘汰最早的条目。
+        """
         if self.ttl_seconds <= 0:
             return
         self._entries[key] = _SearchCacheEntry(
@@ -83,11 +108,19 @@ class SearchCache:
             self._entries.popitem(last=False)
 
     def invalidate_scope(self, *, user_id: str, agent_id: str) -> None:
+        """Drop all cached entries for one user/agent pair.
+
+        丢弃某个 user/agent 对的所有缓存条目。
+        """
         for key in list(self._entries):
             if key.user_id == user_id and key.agent_id == agent_id:
                 self._entries.pop(key, None)
 
     def clear(self) -> None:
+        """Remove all cached entries.
+
+        移除所有缓存条目。
+        """
         self._entries.clear()
 
     def __len__(self) -> int:

--- a/src/middleware/auth.py
+++ b/src/middleware/auth.py
@@ -1,4 +1,7 @@
-"""HTTP authentication middleware."""
+"""HTTP authentication middleware.
+
+HTTP 认证中间件。
+"""
 
 from __future__ import annotations
 
@@ -24,7 +27,10 @@ def _is_public_path(path: str) -> bool:
 
 
 async def auth_middleware(request: Request, call_next) -> Response:
-    """Protect HTTP routes when auth is enabled."""
+    """Protect HTTP routes when auth is enabled.
+
+    当认证开启时保护 HTTP 路由。
+    """
     auth_service = get_auth_service(request.app)
     if not auth_service.enabled or request.method == "OPTIONS" or _is_public_path(request.url.path):
         return await call_next(request)

--- a/src/models/asr.py
+++ b/src/models/asr.py
@@ -1,4 +1,9 @@
-"""ASR API schemas."""
+"""ASR API schemas.
+
+ASR API 数据模式。
+
+Reference: docs/ASR模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -8,7 +13,10 @@ from pydantic import BaseModel, Field
 
 
 class ASRProviderStatus(BaseModel):
-    """Provider metadata plus runtime availability."""
+    """Provider metadata plus runtime availability.
+
+    提供商元数据及运行时可用性。
+    """
 
     name: str
     display_name: str
@@ -23,14 +31,20 @@ class ASRProviderStatus(BaseModel):
 
 
 class ASRConfigResponse(BaseModel):
-    """OLV-shaped ASR config response."""
+    """OLV-shaped ASR config response.
+
+    OLV 格式的 ASR 配置响应。
+    """
 
     config: dict[str, Any]
     providers: list[ASRProviderStatus] = Field(default_factory=list)
 
 
 class ASRHealthResponse(BaseModel):
-    """ASR health response."""
+    """ASR health response.
+
+    ASR 健康检查响应。
+    """
 
     active_provider: str
     active_available: bool
@@ -38,13 +52,19 @@ class ASRHealthResponse(BaseModel):
 
 
 class ASRProviderSwitchRequest(BaseModel):
-    """Switch active provider payload."""
+    """Switch active provider payload.
+
+    切换活跃提供商的请求载荷。
+    """
 
     provider: str = Field(..., min_length=1)
 
 
 class ASRTranscriptionResponse(BaseModel):
-    """Transcription result response."""
+    """Transcription result response.
+
+    转录结果响应。
+    """
 
     provider: str
     text: str

--- a/src/models/character.py
+++ b/src/models/character.py
@@ -1,4 +1,7 @@
-"""Character API schemas used by Phase 7."""
+"""Character API schemas used by Phase 7.
+
+角色 API 数据模式（Phase 7）。
+"""
 
 from __future__ import annotations
 
@@ -6,7 +9,10 @@ from pydantic import BaseModel, Field
 
 
 class CharacterSummary(BaseModel):
-    """Character summary returned by list endpoints."""
+    """Character summary returned by list endpoints.
+
+    列表接口返回的角色摘要。
+    """
 
     character_id: str
     name: str
@@ -20,13 +26,19 @@ class CharacterSummary(BaseModel):
 
 
 class CharacterDetail(CharacterSummary):
-    """Character detail with full system prompt."""
+    """Character detail with full system prompt.
+
+    包含完整系统提示词的角色详情。
+    """
 
     system_prompt: str
 
 
 class CharacterCreateRequest(BaseModel):
-    """Payload for creating a character."""
+    """Payload for creating a character.
+
+    创建角色的请求载荷。
+    """
 
     character_id: str | None = Field(default=None, max_length=64)
     name: str = Field(..., min_length=1, max_length=50)
@@ -36,7 +48,10 @@ class CharacterCreateRequest(BaseModel):
 
 
 class CharacterUpdateRequest(BaseModel):
-    """Payload for updating a character."""
+    """Payload for updating a character.
+
+    更新角色的请求载荷。
+    """
 
     name: str | None = Field(default=None, min_length=1, max_length=50)
     greeting: str | None = None
@@ -45,7 +60,10 @@ class CharacterUpdateRequest(BaseModel):
 
 
 class AvatarUploadResponse(BaseModel):
-    """Response payload for avatar upload."""
+    """Response payload for avatar upload.
+
+    头像上传的响应载荷。
+    """
 
     character_id: str
     avatar: str

--- a/src/models/live2d.py
+++ b/src/models/live2d.py
@@ -1,4 +1,7 @@
-"""Live2D API schemas used by Phase 8."""
+"""Live2D API schemas used by Phase 8.
+
+Live2D API 数据模式（Phase 8）。
+"""
 
 from __future__ import annotations
 
@@ -6,7 +9,10 @@ from pydantic import BaseModel, Field
 
 
 class Live2DModelSummary(BaseModel):
-    """Live2D model summary returned by management endpoints."""
+    """Live2D model summary returned by management endpoints.
+
+    管理接口返回的 Live2D 模型摘要。
+    """
 
     id: str
     name: str
@@ -19,13 +25,19 @@ class Live2DModelSummary(BaseModel):
 
 
 class Live2DExpressionList(BaseModel):
-    """Expression list returned for a specific model."""
+    """Expression list returned for a specific model.
+
+    针对特定模型返回的表情列表。
+    """
 
     model_id: str
     expressions: list[str] = Field(default_factory=list)
 
 
 class Live2DModelUpdateRequest(BaseModel):
-    """Payload for updating one Live2D model."""
+    """Payload for updating one Live2D model.
+
+    更新单个 Live2D 模型的请求载荷。
+    """
 
     name: str = Field(..., min_length=1, max_length=120)

--- a/src/models/tts.py
+++ b/src/models/tts.py
@@ -1,4 +1,9 @@
-"""TTS API schemas."""
+"""TTS API schemas.
+
+TTS API 数据模式。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -8,7 +13,10 @@ from pydantic import BaseModel, Field
 
 
 class TTSProviderStatus(BaseModel):
-    """Provider metadata plus runtime availability."""
+    """Provider metadata plus runtime availability.
+
+    提供商元数据及运行时可用性。
+    """
 
     name: str
     display_name: str
@@ -23,14 +31,20 @@ class TTSProviderStatus(BaseModel):
 
 
 class TTSConfigResponse(BaseModel):
-    """OLV-shaped TTS config response."""
+    """OLV-shaped TTS config response.
+
+    OLV 格式的 TTS 配置响应。
+    """
 
     config: dict[str, Any]
     providers: list[TTSProviderStatus] = Field(default_factory=list)
 
 
 class TTSHealthResponse(BaseModel):
-    """TTS health response."""
+    """TTS health response.
+
+    TTS 健康检查响应。
+    """
 
     active_provider: str
     active_available: bool
@@ -38,13 +52,19 @@ class TTSHealthResponse(BaseModel):
 
 
 class TTSProviderSwitchRequest(BaseModel):
-    """Switch active provider payload."""
+    """Switch active provider payload.
+
+    切换活跃提供商的请求载荷。
+    """
 
     provider: str = Field(..., min_length=1)
 
 
 class TTSVoiceInfo(BaseModel):
-    """Voice metadata for settings UI."""
+    """Voice metadata for settings UI.
+
+    用于设置界面的语音元数据。
+    """
 
     id: str
     name: str
@@ -55,14 +75,20 @@ class TTSVoiceInfo(BaseModel):
 
 
 class TTSVoicesResponse(BaseModel):
-    """Provider voices response."""
+    """Provider voices response.
+
+    提供商语音列表响应。
+    """
 
     provider: str
     voices: list[TTSVoiceInfo] = Field(default_factory=list)
 
 
 class TTSSynthesisRequest(BaseModel):
-    """Complete-text synthesis request."""
+    """Complete-text synthesis request.
+
+    完整文本合成请求。
+    """
 
     text: str = Field(..., min_length=1)
     provider: str | None = None

--- a/src/routes/asr.py
+++ b/src/routes/asr.py
@@ -1,4 +1,7 @@
-"""ASR management and transcription REST API routes."""
+"""ASR management and transcription REST API routes.
+
+ASR 管理与转录 REST API 路由。
+"""
 
 from __future__ import annotations
 
@@ -20,7 +23,10 @@ router = APIRouter(prefix="/api/asr", tags=["asr"])
 
 
 def get_asr_service(request: Request) -> ASRService:
-    """Return app-scoped ASR service, creating a default one if needed."""
+    """Return app-scoped ASR service, creating a default one if needed.
+
+    返回应用级 ASR 服务，若不存在则创建默认实例。
+    """
 
     service = getattr(request.app.state, "asr_service", None)
     if service is None:
@@ -52,14 +58,20 @@ def _handle_asr_error(error: Exception) -> HTTPException:
 
 @router.get("/providers", response_model=list[ASRProviderStatus])
 async def list_asr_providers(service: ASRServiceDep) -> list[ASRProviderStatus]:
-    """List registered ASR providers with health and config state."""
+    """List registered ASR providers with health and config state.
+
+    列出已注册的 ASR 提供商及其健康状态与配置信息。
+    """
 
     return _provider_status_list(service.list_providers())
 
 
 @router.get("/config", response_model=ASRConfigResponse)
 async def get_asr_config(service: ASRServiceDep) -> ASRConfigResponse:
-    """Return current OLV-shaped ASR config and provider statuses."""
+    """Return current OLV-shaped ASR config and provider statuses.
+
+    返回当前 OLV 格式的 ASR 配置和提供商状态。
+    """
 
     return ASRConfigResponse(
         config=service.get_config(),
@@ -72,7 +84,10 @@ async def update_asr_config(
     payload: dict[str, Any],
     service: ASRServiceDep,
 ) -> ASRConfigResponse:
-    """Merge and persist a partial OLV-shaped ASR config update."""
+    """Merge and persist a partial OLV-shaped ASR config update.
+
+    合并并持久化部分 OLV 格式的 ASR 配置更新。
+    """
 
     try:
         service.update_config(payload)
@@ -90,7 +105,10 @@ async def switch_asr_provider(
     payload: ASRProviderSwitchRequest,
     service: ASRServiceDep,
 ) -> ASRConfigResponse:
-    """Switch active ASR provider."""
+    """Switch active ASR provider.
+
+    切换活跃的 ASR 提供商。
+    """
 
     try:
         service.switch_provider(payload.provider)
@@ -105,7 +123,10 @@ async def switch_asr_provider(
 
 @router.get("/health", response_model=ASRHealthResponse)
 async def get_asr_health(service: ASRServiceDep) -> ASRHealthResponse:
-    """Return active provider and all-provider health."""
+    """Return active provider and all-provider health.
+
+    返回活跃提供商及所有提供商的健康状态。
+    """
 
     health = service.health()
     return ASRHealthResponse(
@@ -121,7 +142,10 @@ async def transcribe_audio(
     service: ASRServiceDep,
     provider: str | None = None,
 ) -> ASRTranscriptionResponse:
-    """Transcribe uploaded audio with the active or requested ASR provider."""
+    """Transcribe uploaded audio with the active or requested ASR provider.
+
+    使用活跃或指定的 ASR 提供商转录上传的音频。
+    """
 
     try:
         payload = await audio.read()

--- a/src/routes/auth.py
+++ b/src/routes/auth.py
@@ -1,4 +1,7 @@
-"""Authentication API routes."""
+"""Authentication API routes.
+
+认证 API 路由。
+"""
 
 from __future__ import annotations
 
@@ -132,6 +135,10 @@ def _has_valid_session_cookie(request: Request) -> bool:
 
 @router.get("/status", response_model=AuthStatusResponse)
 async def get_auth_status(request: Request) -> AuthStatusResponse:
+    """Return whether authentication is enabled.
+
+    返回认证是否启用。
+    """
     auth_service = get_auth_service(request.app)
     return AuthStatusResponse(enabled=auth_service.enabled)
 
@@ -142,6 +149,10 @@ async def get_login_url(
     response: Response,
     state: str | None = Query(None),  # Kept for backward-compatible clients; ignored.
 ) -> AuthLoginResponse:
+    """Return the GitHub OAuth authorization URL and set the state cookie.
+
+    返回 GitHub OAuth 授权 URL 并设置 state Cookie。
+    """
     auth_service = get_auth_service(request.app)
     if not auth_service.enabled:
         return AuthLoginResponse(enabled=False, authorization_url=None)
@@ -163,6 +174,10 @@ async def github_callback(
     state: str | None = Query(None),
     error: str | None = Query(None),
 ) -> RedirectResponse:
+    """Handle the GitHub OAuth callback, exchange code for token, and set session.
+
+    处理 GitHub OAuth 回调，将授权码交换为令牌，并设置会话。
+    """
     auth_service = get_auth_service(request.app)
     if not auth_service.enabled:
         return _redirect_with_cleared_oauth_state(
@@ -230,6 +245,10 @@ async def github_callback(
 
 @router.get("/me", response_model=AuthUserResponse)
 async def get_current_user(request: Request) -> AuthUserResponse:
+    """Return the currently authenticated user's profile.
+
+    返回当前已认证用户的资料。
+    """
     auth_service = get_auth_service(request.app)
     if not auth_service.enabled:
         return AuthUserResponse(username=DEFAULT_USER_ID, auth_enabled=False)
@@ -253,5 +272,9 @@ async def get_current_user(request: Request) -> AuthUserResponse:
 
 @router.post("/logout", response_model=AuthLogoutResponse)
 async def logout(request: Request, response: Response) -> AuthLogoutResponse:
+    """Clear the session cookie and log the user out.
+
+    清除会话 Cookie 并登出用户。
+    """
     _clear_session_cookie(request, response)
     return AuthLogoutResponse(success=True)

--- a/src/routes/characters.py
+++ b/src/routes/characters.py
@@ -1,4 +1,7 @@
-"""Character management REST API routes."""
+"""Character management REST API routes.
+
+角色管理 REST API 路由。
+"""
 
 from __future__ import annotations
 
@@ -26,7 +29,10 @@ router = APIRouter(prefix="/api/characters", tags=["characters"])
 
 
 def get_character_storage(request: Request) -> CharacterStorage:
-    """Return app-scoped character storage, creating a default one if needed."""
+    """Return app-scoped character storage, creating a default one if needed.
+
+    返回应用级角色存储，若不存在则创建默认实例。
+    """
 
     storage = getattr(request.app.state, "character_storage", None)
     if storage is None:
@@ -78,7 +84,10 @@ async def list_characters(
     request: Request,
     storage: CharacterStorageDep,
 ) -> list[CharacterSummary]:
-    """List all characters without changing the existing read API shape."""
+    """List all characters without changing the existing read API shape.
+
+    列出所有角色，不改变现有的读取 API 形态。
+    """
 
     records = storage.list_characters()
     return [
@@ -103,7 +112,10 @@ async def get_character(
     request: Request,
     storage: CharacterStorageDep,
 ) -> CharacterDetail:
-    """Get one character with its full system prompt."""
+    """Get one character with its full system prompt.
+
+    获取单个角色及其完整系统提示词。
+    """
 
     try:
         record = storage.get_character(character_id)
@@ -119,7 +131,10 @@ async def create_character(
     request: Request,
     storage: CharacterStorageDep,
 ) -> CharacterDetail:
-    """Create a new character."""
+    """Create a new character.
+
+    创建新角色。
+    """
 
     try:
         record = storage.create_character(
@@ -142,7 +157,10 @@ async def update_character(
     request: Request,
     storage: CharacterStorageDep,
 ) -> CharacterDetail:
-    """Update an existing character."""
+    """Update an existing character.
+
+    更新现有角色。
+    """
 
     try:
         record = storage.update_character(
@@ -163,7 +181,10 @@ async def delete_character(
     character_id: str,
     storage: CharacterStorageDep,
 ) -> Response:
-    """Delete a managed character."""
+    """Delete a managed character.
+
+    删除托管角色。
+    """
 
     try:
         storage.delete_character(character_id)
@@ -180,7 +201,10 @@ async def upload_character_avatar(
     avatar: AvatarFile,
     storage: CharacterStorageDep,
 ) -> AvatarUploadResponse:
-    """Upload or replace a character avatar."""
+    """Upload or replace a character avatar.
+
+    上传或替换角色头像。
+    """
 
     try:
         record = await storage.save_avatar(character_id, avatar)

--- a/src/routes/data.py
+++ b/src/routes/data.py
@@ -1,4 +1,7 @@
-"""Data maintenance REST API routes."""
+"""Data maintenance REST API routes.
+
+数据维护 REST API 路由。
+"""
 
 from __future__ import annotations
 
@@ -20,7 +23,10 @@ _SHORT_TERM_FILENAME = "short_term_memory.json"
 
 
 class DataCleanupResponse(BaseModel):
-    """Response for data cleanup operations."""
+    """Response for data cleanup operations.
+
+    数据清理操作的响应。
+    """
 
     character_id: str
     user_id: str
@@ -96,7 +102,10 @@ async def clear_short_term_memory(
     chat_id: str,
     request: Request,
 ) -> DataCleanupResponse:
-    """Clear short-term memory for current user, character, and chat."""
+    """Clear short-term memory for current user, character, and chat.
+
+    清除当前用户、角色和聊天的短期记忆。
+    """
 
     user_id = get_request_user_id(request)
     await _ensure_user_chat(request, user_id, character_id, chat_id)
@@ -157,7 +166,10 @@ async def clear_long_term_memory(
     character_id: str,
     request: Request,
 ) -> DataCleanupResponse:
-    """Submit long-term memory deletion for current user and character."""
+    """Submit long-term memory deletion for current user and character.
+
+    提交当前用户和角色的长期记忆删除请求。
+    """
 
     user_id = get_request_user_id(request)
     long_term = _get_long_term_memory(request, character_id, user_id)

--- a/src/routes/live2d.py
+++ b/src/routes/live2d.py
@@ -1,4 +1,7 @@
-"""Live2D management REST API routes."""
+"""Live2D management REST API routes.
+
+Live2D 管理 REST API 路由。
+"""
 
 from __future__ import annotations
 
@@ -32,7 +35,10 @@ router = APIRouter(prefix="/api/live2d/models", tags=["live2d"])
 
 
 def get_live2d_storage(request: Request) -> Live2DStorage:
-    """Return app-scoped Live2D storage, creating a default one if needed."""
+    """Return app-scoped Live2D storage, creating a default one if needed.
+
+    返回应用级 Live2D 存储，若不存在则创建默认实例。
+    """
 
     storage = getattr(request.app.state, "live2d_storage", None)
     if storage is None:
@@ -79,7 +85,10 @@ async def list_live2d_models(
     request: Request,
     storage: Live2DStorageDep,
 ) -> list[Live2DModelSummary]:
-    """List all stored Live2D models."""
+    """List all stored Live2D models.
+
+    列出所有存储的 Live2D 模型。
+    """
 
     return [_serialize_model(record, request, storage) for record in storage.list_models()]
 
@@ -91,7 +100,10 @@ async def upload_live2d_model(
     storage: Live2DStorageDep,
     name: str | None = Form(default=None),
 ) -> Live2DModelSummary:
-    """Upload and extract a Live2D ZIP archive."""
+    """Upload and extract a Live2D ZIP archive.
+
+    上传并解压 Live2D ZIP 压缩包。
+    """
 
     try:
         record = await storage.save_model(model, name=name)
@@ -106,7 +118,10 @@ async def get_live2d_expressions(
     model_id: str,
     storage: Live2DStorageDep,
 ) -> Live2DExpressionList:
-    """Return the expression list for one Live2D model."""
+    """Return the expression list for one Live2D model.
+
+    返回单个 Live2D 模型的表情列表。
+    """
 
     try:
         expressions = storage.list_expressions(model_id)
@@ -123,7 +138,10 @@ async def update_live2d_model(
     request: Request,
     storage: Live2DStorageDep,
 ) -> Live2DModelSummary:
-    """Update mutable Live2D model metadata."""
+    """Update mutable Live2D model metadata.
+
+    更新 Live2D 模型的可变元数据。
+    """
 
     try:
         record = storage.update_model(model_id, name=payload.name)
@@ -138,7 +156,10 @@ async def delete_live2d_model(
     model_id: str,
     storage: Live2DStorageDep,
 ) -> Response:
-    """Delete one Live2D model directory."""
+    """Delete one Live2D model directory.
+
+    删除单个 Live2D 模型目录。
+    """
 
     try:
         storage.delete_model(model_id)

--- a/src/routes/tts.py
+++ b/src/routes/tts.py
@@ -1,4 +1,7 @@
-"""TTS management and synthesis REST API routes."""
+"""TTS management and synthesis REST API routes.
+
+TTS 管理与合成 REST API 路由。
+"""
 
 from __future__ import annotations
 
@@ -28,7 +31,10 @@ router = APIRouter(prefix="/api/tts", tags=["tts"])
 
 
 def get_tts_service(request: Request) -> TTSService:
-    """Return app-scoped TTS service, creating a default one if needed."""
+    """Return app-scoped TTS service, creating a default one if needed.
+
+    返回应用级 TTS 服务，若不存在则创建默认实例。
+    """
 
     service = getattr(request.app.state, "tts_service", None)
     if service is None:
@@ -63,14 +69,20 @@ def _handle_tts_error(error: Exception) -> HTTPException:
 
 @router.get("/providers", response_model=list[TTSProviderStatus])
 async def list_tts_providers(service: TTSServiceDep) -> list[TTSProviderStatus]:
-    """List registered TTS providers with health and config state."""
+    """List registered TTS providers with health and config state.
+
+    列出已注册的 TTS 提供商及其健康状态与配置信息。
+    """
 
     return _provider_status_list(service.list_providers())
 
 
 @router.get("/config", response_model=TTSConfigResponse)
 async def get_tts_config(service: TTSServiceDep) -> TTSConfigResponse:
-    """Return current OLV-shaped TTS config and provider statuses."""
+    """Return current OLV-shaped TTS config and provider statuses.
+
+    返回当前 OLV 格式的 TTS 配置和提供商状态。
+    """
 
     return TTSConfigResponse(
         config=service.get_config(),
@@ -83,7 +95,10 @@ async def update_tts_config(
     payload: dict[str, Any],
     service: TTSServiceDep,
 ) -> TTSConfigResponse:
-    """Merge and persist a partial OLV-shaped TTS config update."""
+    """Merge and persist a partial OLV-shaped TTS config update.
+
+    合并并持久化部分 OLV 格式的 TTS 配置更新。
+    """
 
     try:
         service.update_config(payload)
@@ -101,7 +116,10 @@ async def switch_tts_provider(
     payload: TTSProviderSwitchRequest,
     service: TTSServiceDep,
 ) -> TTSConfigResponse:
-    """Switch active TTS provider."""
+    """Switch active TTS provider.
+
+    切换活跃的 TTS 提供商。
+    """
 
     try:
         service.switch_provider(payload.provider)
@@ -116,7 +134,10 @@ async def switch_tts_provider(
 
 @router.get("/health", response_model=TTSHealthResponse)
 async def get_tts_health(service: TTSServiceDep) -> TTSHealthResponse:
-    """Return active provider and all-provider health."""
+    """Return active provider and all-provider health.
+
+    返回活跃提供商及所有提供商的健康状态。
+    """
 
     health = service.health()
     return TTSHealthResponse(
@@ -131,7 +152,10 @@ async def get_tts_voices(
     service: TTSServiceDep,
     provider: str | None = None,
 ) -> TTSVoicesResponse:
-    """Return voices for active or requested TTS provider."""
+    """Return voices for active or requested TTS provider.
+
+    返回活跃或指定 TTS 提供商的语音列表。
+    """
 
     try:
         result = await service.get_voices(provider=provider)
@@ -145,7 +169,10 @@ async def synthesize_text(
     payload: TTSSynthesisRequest,
     service: TTSServiceDep,
 ) -> Response:
-    """Synthesize text with the active or requested TTS provider."""
+    """Synthesize text with the active or requested TTS provider.
+
+    使用活跃或指定的 TTS 提供商合成文本。
+    """
 
     logger.info(
         "TTS synth request received | provider={} | text_len={} | voice_id={} | options_keys={}",

--- a/src/storage/character_storage.py
+++ b/src/storage/character_storage.py
@@ -1,4 +1,7 @@
-"""Character storage backed by persona markdown files and managed avatars."""
+"""Character storage backed by persona markdown files and managed avatars.
+
+基于角色 markdown 文件和托管头像的角色存储。
+"""
 
 from __future__ import annotations
 
@@ -51,28 +54,46 @@ _DEFAULT_AVATAR_DIR = _PROJECT_ROOT / "data" / "avatars"
 
 
 class CharacterStorageError(Exception):
-    """Base exception for character storage operations."""
+    """Base exception for character storage operations.
+
+    角色存储操作的基异常。
+    """
 
 
 class CharacterNotFoundError(CharacterStorageError):
-    """Raised when a character file does not exist."""
+    """Raised when a character file does not exist.
+
+    当角色文件不存在时抛出。
+    """
 
 
 class CharacterNameConflictError(CharacterStorageError):
-    """Raised when a character name duplicates another character."""
+    """Raised when a character name duplicates another character.
+
+    当角色名称与已有角色重复时抛出。
+    """
 
 
 class CharacterSystemDeleteError(CharacterStorageError):
-    """Raised when attempting to delete a protected system character."""
+    """Raised when attempting to delete a protected system character.
+
+    当尝试删除受保护的系统角色时抛出。
+    """
 
 
 class AvatarValidationError(CharacterStorageError):
-    """Raised when avatar upload validation fails."""
+    """Raised when avatar upload validation fails.
+
+    当头像上传校验失败时抛出。
+    """
 
 
 @dataclass(frozen=True)
 class CharacterRecord:
-    """Character record loaded from persona markdown."""
+    """Character record loaded from persona markdown.
+
+    从角色 markdown 文件加载的角色记录。
+    """
 
     character_id: str
     name: str
@@ -86,17 +107,27 @@ class CharacterRecord:
 
     @property
     def is_system(self) -> bool:
+        """Return True if this character is a protected system character.
+
+        若该角色为受保护的系统角色则返回 True。
+        """
         return self.managed_by != MANAGED_BY_ATRI
 
 
 def get_default_character_persona_dir() -> Path:
-    """Return the default persona directory used by the backend."""
+    """Return the default persona directory used by the backend.
+
+    返回后端使用的默认角色文件目录。
+    """
 
     return _DEFAULT_PERSONA_DIR
 
 
 def get_default_character_avatar_dir() -> Path:
-    """Return the default managed avatar directory used by the backend."""
+    """Return the default managed avatar directory used by the backend.
+
+    返回后端使用的默认托管头像目录。
+    """
 
     return _DEFAULT_AVATAR_DIR
 
@@ -129,9 +160,16 @@ def _validate_custom_character_name(name: str) -> None:
 
 
 class CharacterStorage:
-    """Read and write characters using persona markdown files."""
+    """Read and write characters using persona markdown files.
+
+    使用角色 markdown 文件读写角色信息。
+    """
 
     def __init__(self, persona_dir: Path | None = None, avatar_dir: Path | None = None) -> None:
+        """Initialize the character storage with optional custom directories.
+
+        使用可选的自定义目录初始化角色存储。
+        """
         self.persona_dir = persona_dir or get_default_character_persona_dir()
         self.avatar_dir = avatar_dir or get_default_character_avatar_dir()
 
@@ -139,13 +177,19 @@ class CharacterStorage:
         self.avatar_dir.mkdir(parents=True, exist_ok=True)
 
     def list_characters(self) -> list[CharacterRecord]:
-        """List all character records sorted by name."""
+        """List all character records sorted by name.
+
+        列出所有角色记录，按名称排序。
+        """
 
         records = [self.get_character(path.stem) for path in sorted(self.persona_dir.glob("*.md"))]
         return sorted(records, key=lambda record: (record.name.casefold(), record.character_id))
 
     def get_character(self, character_id: str) -> CharacterRecord:
-        """Load a single character by its identifier."""
+        """Load a single character by its identifier.
+
+        根据标识符加载单个角色。
+        """
 
         path = self._character_path(character_id)
         if not path.is_file():
@@ -163,7 +207,10 @@ class CharacterStorage:
         description: str | None,
         system_prompt: str,
     ) -> CharacterRecord:
-        """Create a new managed character."""
+        """Create a new managed character.
+
+        创建新的托管角色。
+        """
 
         clean_name = name.strip()
         clean_system_prompt = system_prompt.strip()
@@ -203,7 +250,10 @@ class CharacterStorage:
         description: str | None = None,
         system_prompt: str | None = None,
     ) -> CharacterRecord:
-        """Update an existing character."""
+        """Update an existing character.
+
+        更新已有角色。
+        """
 
         current = self.get_character(character_id)
 
@@ -238,7 +288,10 @@ class CharacterStorage:
         return record
 
     def delete_character(self, character_id: str) -> None:
-        """Delete a managed character and its uploaded avatar, if any."""
+        """Delete a managed character and its uploaded avatar, if any.
+
+        删除托管角色及其已上传的头像（如有）。
+        """
 
         record = self.get_character(character_id)
         if record.is_system:
@@ -252,7 +305,10 @@ class CharacterStorage:
             avatar_path.unlink(missing_ok=True)
 
     async def save_avatar(self, character_id: str, file: UploadFile) -> CharacterRecord:
-        """Validate and store an uploaded avatar for a character."""
+        """Validate and store an uploaded avatar for a character.
+
+        校验并存储角色上传的头像。
+        """
 
         current = self.get_character(character_id)
         extension = self._resolve_avatar_extension(file)
@@ -286,7 +342,10 @@ class CharacterStorage:
         return record
 
     def build_avatar_url(self, avatar: str | None, base_url: str) -> str | None:
-        """Build an absolute backend avatar URL for managed avatars."""
+        """Build an absolute backend avatar URL for managed avatars.
+
+        为托管头像构建后端绝对 URL。
+        """
 
         managed_path = self._managed_avatar_path(avatar)
         if avatar is None or managed_path is None or not managed_path.is_file():

--- a/src/storage/db_storage.py
+++ b/src/storage/db_storage.py
@@ -1,12 +1,22 @@
-"""Placeholder for DatabaseChatStorage (Phase 7)."""
+"""Placeholder for DatabaseChatStorage (Phase 7).
+
+DatabaseChatStorage 的占位实现（Phase 7）。
+"""
 
 from src.storage.interface import ChatStorageInterface
 
 
 class DatabaseChatStorage(ChatStorageInterface):
-    """Database-backed chat storage (reserved for Phase 7)."""
+    """Database-backed chat storage (reserved for Phase 7).
+
+    基于数据库的聊天存储（为 Phase 7 预留）。
+    """
 
     def __init__(self, database_url: str):
+        """Initialize the database storage with a connection URL.
+
+        使用数据库连接 URL 初始化存储。
+        """
         self.database_url = database_url
 
     async def create_chat(self, user_id: str, character_id: str, title: str) -> dict:

--- a/src/storage/interface.py
+++ b/src/storage/interface.py
@@ -1,28 +1,35 @@
-"""
-Abstract interface for chat storage.
+"""Abstract interface for chat storage.
 
 Defines the contract for chat persistence implementations (JSON, database, etc.).
+
+聊天存储的抽象接口，定义了聊天持久化实现（JSON、数据库等）的契约。
 """
 
 from abc import ABC, abstractmethod
 
 
 class ChatStorageInterface(ABC):
-    """Abstract interface for chat storage operations."""
+    """Abstract interface for chat storage operations.
+
+    聊天存储操作的抽象接口。
+    """
 
     @abstractmethod
     async def create_chat(self, user_id: str, character_id: str, title: str) -> dict:
         """
         Create a new chat session.
 
+        创建新的聊天会话。
+
         Args:
-            user_id: User identifier
-            character_id: Character identifier
-            title: Chat title (LLM-generated or fallback)
+            user_id: User identifier / 用户标识符
+            character_id: Character identifier / 角色标识符
+            title: Chat title (LLM-generated or fallback) / 聊天标题（LLM 生成或回退）
 
         Returns:
             Chat metadata dict with keys: id, title, character_id,
             created_at, updated_at, message_count
+            聊天元数据字典，包含键：id, title, character_id, created_at, updated_at, message_count
         """
         ...
 
@@ -31,12 +38,14 @@ class ChatStorageInterface(ABC):
         """
         List user's chat sessions, sorted by updated_at descending.
 
+        列出用户的聊天会话，按 updated_at 降序排列。
+
         Args:
-            user_id: User identifier
-            character_id: Optional filter by character
+            user_id: User identifier / 用户标识符
+            character_id: Optional filter by character / 可选的角色过滤条件
 
         Returns:
-            List of chat metadata dicts
+            List of chat metadata dicts / 聊天元数据字典列表
         """
         ...
 
@@ -45,11 +54,14 @@ class ChatStorageInterface(ABC):
         """
         Get chat metadata by ID.
 
+        根据 ID 获取聊天元数据。
+
         Args:
-            chat_id: Chat identifier
+            chat_id: Chat identifier / 聊天标识符
 
         Returns:
             Chat metadata dict or None if not found
+            聊天元数据字典，未找到时返回 None
         """
         ...
 
@@ -58,12 +70,15 @@ class ChatStorageInterface(ABC):
         """
         Get chat metadata by ID, scoped to a user.
 
+        根据 ID 获取聊天元数据，限定到特定用户。
+
         Args:
-            user_id: User identifier
-            chat_id: Chat identifier
+            user_id: User identifier / 用户标识符
+            chat_id: Chat identifier / 聊天标识符
 
         Returns:
             Chat metadata dict or None if not found for this user
+            聊天元数据字典，该用户下未找到时返回 None
         """
         ...
 
@@ -74,13 +89,16 @@ class ChatStorageInterface(ABC):
         """
         Get chat metadata by ID, scoped to a user and character.
 
+        根据 ID 获取聊天元数据，限定到特定用户和角色。
+
         Args:
-            user_id: User identifier
-            character_id: Character identifier
-            chat_id: Chat identifier
+            user_id: User identifier / 用户标识符
+            character_id: Character identifier / 角色标识符
+            chat_id: Chat identifier / 聊天标识符
 
         Returns:
             Chat metadata dict or None if not found for this user/character
+            聊天元数据字典，该用户/角色下未找到时返回 None
         """
         ...
 
@@ -89,15 +107,17 @@ class ChatStorageInterface(ABC):
         """
         Update chat metadata (e.g., title).
 
+        更新聊天元数据（如标题）。
+
         Args:
-            chat_id: Chat identifier
-            **kwargs: Fields to update (e.g., title="New Title")
+            chat_id: Chat identifier / 聊天标识符
+            **kwargs: Fields to update (e.g., title="New Title") / 要更新的字段
 
         Returns:
-            Updated chat metadata dict
+            Updated chat metadata dict / 更新后的聊天元数据字典
 
         Raises:
-            ValueError: If chat_id not found
+            ValueError: If chat_id not found / 聊天 ID 不存在时抛出
         """
         ...
 
@@ -106,16 +126,18 @@ class ChatStorageInterface(ABC):
         """
         Update chat metadata for a specific user.
 
+        更新特定用户的聊天元数据。
+
         Args:
-            user_id: User identifier
-            chat_id: Chat identifier
-            **kwargs: Fields to update
+            user_id: User identifier / 用户标识符
+            chat_id: Chat identifier / 聊天标识符
+            **kwargs: Fields to update / 要更新的字段
 
         Returns:
-            Updated chat metadata dict
+            Updated chat metadata dict / 更新后的聊天元数据字典
 
         Raises:
-            ValueError: If chat_id not found for this user
+            ValueError: If chat_id not found for this user / 该用户下聊天 ID 不存在时抛出
         """
         ...
 
@@ -124,11 +146,13 @@ class ChatStorageInterface(ABC):
         """
         Delete a chat session and its messages.
 
+        删除聊天会话及其消息。
+
         Args:
-            chat_id: Chat identifier
+            chat_id: Chat identifier / 聊天标识符
 
         Raises:
-            ValueError: If chat_id not found
+            ValueError: If chat_id not found / 聊天 ID 不存在时抛出
         """
         ...
 
@@ -137,12 +161,14 @@ class ChatStorageInterface(ABC):
         """
         Delete a chat session for a specific user.
 
+        删除特定用户的聊天会话。
+
         Args:
-            user_id: User identifier
-            chat_id: Chat identifier
+            user_id: User identifier / 用户标识符
+            chat_id: Chat identifier / 聊天标识符
 
         Raises:
-            ValueError: If chat_id not found for this user
+            ValueError: If chat_id not found for this user / 该用户下聊天 ID 不存在时抛出
         """
         ...
 
@@ -153,17 +179,20 @@ class ChatStorageInterface(ABC):
         """
         Append a message to chat history.
 
+        向聊天历史追加消息。
+
         Args:
-            chat_id: Chat identifier
-            role: Message role (human/ai/system)
-            content: Message content
-            name: Optional speaker name
+            chat_id: Chat identifier / 聊天标识符
+            role: Message role (human/ai/system) / 消息角色（human/ai/system）
+            content: Message content / 消息内容
+            name: Optional speaker name / 可选的发言者名称
 
         Returns:
             Message dict with keys: role, content, name, timestamp
+            消息字典，包含键：role, content, name, timestamp
 
         Raises:
-            ValueError: If chat_id not found
+            ValueError: If chat_id not found / 聊天 ID 不存在时抛出
         """
         ...
 
@@ -174,18 +203,20 @@ class ChatStorageInterface(ABC):
         """
         Append a message to a user-scoped chat history.
 
+        向用户范围的聊天历史追加消息。
+
         Args:
-            user_id: User identifier
-            chat_id: Chat identifier
-            role: Message role
-            content: Message content
-            name: Optional speaker name
+            user_id: User identifier / 用户标识符
+            chat_id: Chat identifier / 聊天标识符
+            role: Message role / 消息角色
+            content: Message content / 消息内容
+            name: Optional speaker name / 可选的发言者名称
 
         Returns:
-            Message dict
+            Message dict / 消息字典
 
         Raises:
-            ValueError: If chat_id not found for this user
+            ValueError: If chat_id not found for this user / 该用户下聊天 ID 不存在时抛出
         """
         ...
 
@@ -194,16 +225,18 @@ class ChatStorageInterface(ABC):
         """
         Get chat message history with pagination.
 
+        分页获取聊天消息历史。
+
         Args:
-            chat_id: Chat identifier
-            limit: Maximum messages to return
-            offset: Number of messages to skip
+            chat_id: Chat identifier / 聊天标识符
+            limit: Maximum messages to return / 返回的最大消息数
+            offset: Number of messages to skip / 跳过的消息数
 
         Returns:
-            List of message dicts
+            List of message dicts / 消息字典列表
 
         Raises:
-            ValueError: If chat_id not found
+            ValueError: If chat_id not found / 聊天 ID 不存在时抛出
         """
         ...
 
@@ -214,16 +247,18 @@ class ChatStorageInterface(ABC):
         """
         Get user-scoped chat message history with pagination.
 
+        分页获取用户范围的聊天消息历史。
+
         Args:
-            user_id: User identifier
-            chat_id: Chat identifier
-            limit: Maximum messages to return
-            offset: Number of messages to skip
+            user_id: User identifier / 用户标识符
+            chat_id: Chat identifier / 聊天标识符
+            limit: Maximum messages to return / 返回的最大消息数
+            offset: Number of messages to skip / 跳过的消息数
 
         Returns:
-            List of message dicts
+            List of message dicts / 消息字典列表
 
         Raises:
-            ValueError: If chat_id not found for this user
+            ValueError: If chat_id not found for this user / 该用户下聊天 ID 不存在时抛出
         """
         ...

--- a/src/storage/json_storage.py
+++ b/src/storage/json_storage.py
@@ -1,4 +1,7 @@
-"""JSON file-based chat storage implementation."""
+"""JSON file-based chat storage implementation.
+
+基于 JSON 文件的聊天存储实现。
+"""
 
 import asyncio
 import json
@@ -12,12 +15,21 @@ from src.storage.interface import ChatStorageInterface
 
 
 class _ChatLocation(NamedTuple):
+    """Internal record pointing to a chat's location on disk.
+
+    内部记录，指向聊天在磁盘上的位置。
+    """
+
     user_id: str
     character_id: str
     chat: dict
 
 
 def _validate_path_component(label: str, value: str) -> str:
+    """Validate a string as a safe single-path component.
+
+    校验字符串是否为安全的单级路径分量。
+    """
     if not isinstance(value, str):
         raise ValueError(f"{label} must be a string")
     clean = value.strip()
@@ -35,28 +47,47 @@ def _validate_path_component(label: str, value: str) -> str:
 
 
 class JSONChatStorage(ChatStorageInterface):
-    """JSON file-based chat storage with file system persistence."""
+    """JSON file-based chat storage with file system persistence.
+
+    基于 JSON 文件的聊天存储，使用文件系统进行持久化。
+    """
 
     def __init__(self, base_path: str):
+        """Initialize the storage with a base directory path.
+
+        使用指定的根目录路径初始化存储。
+        """
         self.base_path = Path(base_path)
 
     def _get_user_dir(self, user_id: str, character_id: str) -> Path:
-        """Get user-character directory path."""
+        """Get user-character directory path.
+
+        获取用户-角色目录路径。
+        """
         safe_user_id = _validate_path_component("user_id", user_id)
         safe_character_id = _validate_path_component("character_id", character_id)
         return self.base_path / safe_user_id / safe_character_id
 
     def _get_index_path(self, user_id: str, character_id: str) -> Path:
-        """Get index.json path."""
+        """Get index.json path.
+
+        获取 index.json 文件路径。
+        """
         return self._get_user_dir(user_id, character_id) / "index.json"
 
     def _get_session_path(self, user_id: str, character_id: str, chat_id: str) -> Path:
-        """Get session file path."""
+        """Get session file path.
+
+        获取会话文件路径。
+        """
         safe_chat_id = _validate_path_component("chat_id", chat_id)
         return self._get_user_dir(user_id, character_id) / "sessions" / f"{safe_chat_id}.json"
 
     async def _read_json(self, path: Path) -> dict | list | None:
-        """Read JSON file asynchronously."""
+        """Read JSON file asynchronously.
+
+        异步读取 JSON 文件。
+        """
 
         def _read():
             if not path.exists():
@@ -67,7 +98,10 @@ class JSONChatStorage(ChatStorageInterface):
         return await asyncio.to_thread(_read)
 
     async def _write_json(self, path: Path, data: dict | list) -> None:
-        """Write JSON file atomically."""
+        """Write JSON file atomically.
+
+        原子写入 JSON 文件。
+        """
 
         def _write():
             path.parent.mkdir(parents=True, exist_ok=True)
@@ -79,7 +113,10 @@ class JSONChatStorage(ChatStorageInterface):
         await asyncio.to_thread(_write)
 
     async def _load_index(self, user_id: str, character_id: str) -> dict:
-        """Load index.json or return empty structure."""
+        """Load index.json or return empty structure.
+
+        加载 index.json，若不存在则返回空结构。
+        """
         index_path = self._get_index_path(user_id, character_id)
         data = await self._read_json(index_path)
         if isinstance(data, dict):
@@ -87,12 +124,18 @@ class JSONChatStorage(ChatStorageInterface):
         return {"chats": []}
 
     async def _save_index(self, user_id: str, character_id: str, index: dict) -> None:
-        """Save index.json atomically."""
+        """Save index.json atomically.
+
+        原子保存 index.json。
+        """
         index_path = self._get_index_path(user_id, character_id)
         await self._write_json(index_path, index)
 
     def _generate_chat_id(self) -> str:
-        """Generate chat ID in format: YYYYMMDD_uuid8."""
+        """Generate chat ID in format: YYYYMMDD_uuid8.
+
+        生成聊天 ID，格式为 YYYYMMDD_uuid8。
+        """
         date_str = datetime.now(UTC).strftime("%Y%m%d")
         uuid_str = str(uuid.uuid4())[:8]
         return f"{date_str}_{uuid_str}"
@@ -103,7 +146,10 @@ class JSONChatStorage(ChatStorageInterface):
         user_id: str | None = None,
         character_id: str | None = None,
     ) -> _ChatLocation | None:
-        """Find a chat location, optionally scoped to one user/character."""
+        """Find a chat location, optionally scoped to one user/character.
+
+        查找聊天位置，可限定到特定用户/角色。
+        """
         safe_chat_id = _validate_path_component("chat_id", chat_id)
         safe_user_id = (
             _validate_path_component("user_id", user_id) if user_id is not None else None
@@ -139,7 +185,10 @@ class JSONChatStorage(ChatStorageInterface):
         return None
 
     async def create_chat(self, user_id: str, character_id: str, title: str) -> dict:
-        """Create a new chat session."""
+        """Create a new chat session.
+
+        创建新的聊天会话。
+        """
         chat_id = self._generate_chat_id()
         now = datetime.now(UTC).isoformat()
 
@@ -164,7 +213,10 @@ class JSONChatStorage(ChatStorageInterface):
         return chat_meta
 
     async def list_chats(self, user_id: str, character_id: str | None = None) -> list[dict]:
-        """List user's chat sessions, sorted by updated_at descending."""
+        """List user's chat sessions, sorted by updated_at descending.
+
+        列出用户的聊天会话，按 updated_at 降序排列。
+        """
         if character_id:
             index = await self._load_index(user_id, character_id)
             chats = index["chats"]
@@ -184,19 +236,28 @@ class JSONChatStorage(ChatStorageInterface):
         return chats
 
     async def get_chat(self, chat_id: str) -> dict | None:
-        """Get chat metadata by ID (requires scanning all user directories)."""
+        """Get chat metadata by ID (requires scanning all user directories).
+
+        根据 ID 获取聊天元数据（需要扫描所有用户目录）。
+        """
         location = await self._find_chat_location(chat_id)
         return location.chat if location else None
 
     async def get_chat_for_user(self, user_id: str, chat_id: str) -> dict | None:
-        """Get chat metadata by ID, scoped to a user."""
+        """Get chat metadata by ID, scoped to a user.
+
+        根据 ID 获取聊天元数据，限定到特定用户。
+        """
         location = await self._find_chat_location(chat_id, user_id=user_id)
         return location.chat if location else None
 
     async def get_chat_for_user_character(
         self, user_id: str, character_id: str, chat_id: str
     ) -> dict | None:
-        """Get chat metadata by ID, scoped to one user-character index."""
+        """Get chat metadata by ID, scoped to one user-character index.
+
+        根据 ID 获取聊天元数据，限定到特定用户-角色索引。
+        """
         location = await self._find_chat_location(
             chat_id,
             user_id=user_id,
@@ -205,14 +266,20 @@ class JSONChatStorage(ChatStorageInterface):
         return location.chat if location else None
 
     async def update_chat(self, chat_id: str, **kwargs: str) -> dict:
-        """Update chat metadata (title, etc.)."""
+        """Update chat metadata (title, etc.).
+
+        更新聊天元数据（如标题等）。
+        """
         location = await self._find_chat_location(chat_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")
         return await self.update_chat_for_user(location.user_id, chat_id, **kwargs)
 
     async def update_chat_for_user(self, user_id: str, chat_id: str, **kwargs: str) -> dict:
-        """Update chat metadata for a specific user."""
+        """Update chat metadata for a specific user.
+
+        更新特定用户的聊天元数据。
+        """
         location = await self._find_chat_location(chat_id, user_id=user_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")
@@ -227,14 +294,20 @@ class JSONChatStorage(ChatStorageInterface):
         raise ValueError(f"Chat {chat_id} not found")
 
     async def delete_chat(self, chat_id: str) -> None:
-        """Delete chat session."""
+        """Delete chat session.
+
+        删除聊天会话。
+        """
         location = await self._find_chat_location(chat_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")
         await self.delete_chat_for_user(location.user_id, chat_id)
 
     async def delete_chat_for_user(self, user_id: str, chat_id: str) -> None:
-        """Delete chat session for a specific user."""
+        """Delete chat session for a specific user.
+
+        删除特定用户的聊天会话。
+        """
         location = await self._find_chat_location(chat_id, user_id=user_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")
@@ -258,7 +331,10 @@ class JSONChatStorage(ChatStorageInterface):
     async def append_message(
         self, chat_id: str, role: str, content: str, name: str | None = None
     ) -> dict:
-        """Append message to chat session."""
+        """Append message to chat session.
+
+        向聊天会话追加消息。
+        """
         location = await self._find_chat_location(chat_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")
@@ -273,7 +349,10 @@ class JSONChatStorage(ChatStorageInterface):
     async def append_message_for_user(
         self, user_id: str, chat_id: str, role: str, content: str, name: str | None = None
     ) -> dict:
-        """Append message to a user-scoped chat session."""
+        """Append message to a user-scoped chat session.
+
+        向用户范围的聊天会话追加消息。
+        """
         location = await self._find_chat_location(chat_id, user_id=user_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")
@@ -312,7 +391,10 @@ class JSONChatStorage(ChatStorageInterface):
         limit: int | None = 50,
         offset: int = 0,
     ) -> list[dict]:
-        """Get chat message history with pagination."""
+        """Get chat message history with pagination.
+
+        分页获取聊天消息历史。
+        """
         location = await self._find_chat_location(chat_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")
@@ -330,7 +412,10 @@ class JSONChatStorage(ChatStorageInterface):
         limit: int | None = 50,
         offset: int = 0,
     ) -> list[dict]:
-        """Get user-scoped chat message history with pagination."""
+        """Get user-scoped chat message history with pagination.
+
+        分页获取用户范围的聊天消息历史。
+        """
         location = await self._find_chat_location(chat_id, user_id=user_id)
         if not location:
             raise ValueError(f"Chat {chat_id} not found")

--- a/src/storage/live2d_storage.py
+++ b/src/storage/live2d_storage.py
@@ -1,4 +1,7 @@
-"""Live2D model storage backed by extracted ZIP archives."""
+"""Live2D model storage backed by extracted ZIP archives.
+
+基于解压 ZIP 归档的 Live2D 模型存储。
+"""
 
 from __future__ import annotations
 
@@ -32,20 +35,32 @@ _DEFAULT_AIRI_HIYORI_ARCHIVE = (
 
 
 class Live2DStorageError(Exception):
-    """Base exception for Live2D storage operations."""
+    """Base exception for Live2D storage operations.
+
+    Live2D 存储操作的基异常。
+    """
 
 
 class Live2DModelNotFoundError(Live2DStorageError):
-    """Raised when a model directory or metadata file is missing."""
+    """Raised when a model directory or metadata file is missing.
+
+    当模型目录或元数据文件缺失时抛出。
+    """
 
 
 class Live2DArchiveValidationError(Live2DStorageError):
-    """Raised when an uploaded archive is invalid."""
+    """Raised when an uploaded archive is invalid.
+
+    当上传的归档无效时抛出。
+    """
 
 
 @dataclass(frozen=True)
 class Live2DModelRecord:
-    """Stored Live2D model metadata."""
+    """Stored Live2D model metadata.
+
+    存储的 Live2D 模型元数据。
+    """
 
     id: str
     name: str
@@ -57,13 +72,19 @@ class Live2DModelRecord:
 
 
 def get_default_live2d_root_dir() -> Path:
-    """Return the default Live2D root directory."""
+    """Return the default Live2D root directory.
+
+    返回默认的 Live2D 根目录。
+    """
 
     return _DEFAULT_LIVE2D_ROOT_DIR
 
 
 def get_default_live2d_models_dir() -> Path:
-    """Return the default Live2D models directory served as static assets."""
+    """Return the default Live2D models directory served as static assets.
+
+    返回默认的 Live2D 模型目录（用作静态资源）。
+    """
 
     return _DEFAULT_LIVE2D_MODELS_DIR
 
@@ -93,9 +114,16 @@ def _derive_model_name(filename: str) -> str:
 
 
 class Live2DStorage:
-    """Read and write Live2D models from extracted ZIP archives."""
+    """Read and write Live2D models from extracted ZIP archives.
+
+    从解压的 ZIP 归档中读写 Live2D 模型。
+    """
 
     def __init__(self, models_dir: Path | None = None, *, seed_default: bool | None = None) -> None:
+        """Initialize the Live2D storage with an optional models directory.
+
+        使用可选的模型目录初始化 Live2D 存储。
+        """
         self.models_dir = models_dir or get_default_live2d_models_dir()
         self.models_dir.mkdir(parents=True, exist_ok=True)
         self.seed_default = (
@@ -106,7 +134,10 @@ class Live2DStorage:
         self._default_seed_attempted = False
 
     def list_models(self) -> list[Live2DModelRecord]:
-        """List all available Live2D models."""
+        """List all available Live2D models.
+
+        列出所有可用的 Live2D 模型。
+        """
 
         self.ensure_default_model()
         records = [
@@ -117,7 +148,10 @@ class Live2DStorage:
         )
 
     def get_model(self, model_id: str) -> Live2DModelRecord:
-        """Load one Live2D model metadata record."""
+        """Load one Live2D model metadata record.
+
+        加载单个 Live2D 模型的元数据记录。
+        """
 
         model_dir = self._model_dir(model_id)
         metadata_path = model_dir / "metadata.json"
@@ -138,7 +172,10 @@ class Live2DStorage:
     async def save_model(
         self, archive: UploadFile, *, name: str | None = None
     ) -> Live2DModelRecord:
-        """Persist an uploaded Live2D ZIP archive."""
+        """Persist an uploaded Live2D ZIP archive.
+
+        持久化上传的 Live2D ZIP 归档。
+        """
 
         archive_name = archive.filename or "live2d-model.zip"
         if Path(archive_name).suffix.lower() != ".zip":
@@ -154,7 +191,10 @@ class Live2DStorage:
         return self._save_archive_bytes(payload, archive_name, name=name)
 
     def delete_model(self, model_id: str) -> None:
-        """Delete a stored Live2D model."""
+        """Delete a stored Live2D model.
+
+        删除已存储的 Live2D 模型。
+        """
 
         record = self.get_model(model_id)
         model_dir = self._model_dir(record.id)
@@ -177,7 +217,10 @@ class Live2DStorage:
                 )
 
     def update_model(self, model_id: str, *, name: str) -> Live2DModelRecord:
-        """Update mutable model metadata."""
+        """Update mutable model metadata.
+
+        更新可变的模型元数据。
+        """
 
         record = self.get_model(model_id)
         next_name = name.strip()
@@ -197,18 +240,27 @@ class Live2DStorage:
         return next_record
 
     def list_expressions(self, model_id: str) -> list[str]:
-        """Return the model's available expression names."""
+        """Return the model's available expression names.
+
+        返回模型可用的表情名称列表。
+        """
 
         return self.get_model(model_id).expressions
 
     def build_asset_url(self, relative_path: str, base_url: str) -> str:
-        """Build an absolute asset URL for a stored Live2D file."""
+        """Build an absolute asset URL for a stored Live2D file.
+
+        为存储的 Live2D 文件构建绝对资源 URL。
+        """
 
         clean_base = base_url.rstrip("/")
         return f"{clean_base}/api/assets/live2d/{quote(relative_path)}"
 
     def ensure_default_model(self) -> None:
-        """Best-effort seed of AIRI's cached Hiyori model for local development."""
+        """Best-effort seed of AIRI's cached Hiyori model for local development.
+
+        尽力从 AIRI 缓存中导入 Hiyori 模型，用于本地开发。
+        """
 
         if not self.seed_default or self._default_seed_attempted:
             return

--- a/src/tts/config.py
+++ b/src/tts/config.py
@@ -1,4 +1,14 @@
-"""TTS configuration loading and persistence."""
+"""TTS configuration loading and persistence.
+
+TTS 配置加载与持久化模块。
+
+Provides a YAML-backed config store with deep-merge semantics, environment
+variable placeholder preservation, and safe secret handling.
+
+提供基于 YAML 的配置存储，支持深度合并语义、环境变量占位符保留和安全的密钥处理。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -36,7 +46,26 @@ DEFAULT_TTS_CONFIG: dict[str, Any] = {
 
 
 def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
-    """Recursively merge mappings without mutating inputs."""
+    """Recursively merge mappings without mutating inputs.
+
+    递归合并两个字典，不修改原始输入。
+
+    When both ``base`` and ``override`` contain a dict value for the same key,
+    the sub-dicts are merged recursively; otherwise the override value wins.
+
+    当 ``base`` 和 ``override`` 中同一键对应的值都是字典时，递归合并子字典；
+    否则以 override 的值为准。
+
+    Args:
+        base: The base mapping.
+              基础字典。
+        override: The mapping whose values take precedence.
+                  优先级更高的覆盖字典。
+
+    Returns:
+        A new merged dict. Returns a new merged dict (deep copy).
+        合并后的新字典（深拷贝）。
+    """
 
     result = deepcopy(base)
     for key, value in override.items():
@@ -48,7 +77,18 @@ def deep_merge(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]
 
 
 class TTSConfigStore:
-    """Small YAML-backed configuration store for TTS settings."""
+    """Small YAML-backed configuration store for TTS settings.
+
+    小型 YAML 配置存储，用于管理 TTS 设置。
+
+    Merges on-disk YAML with runtime defaults and optional initial overrides.
+    Sensitive keys (api_key, token, etc.) are preserved across disk refreshes
+    so that resolved environment-variable values are not lost.
+
+    将磁盘上的 YAML 与运行时默认值和可选的初始覆盖值合并。
+    敏感键（api_key、token 等）在磁盘刷新时会被保留，
+    以确保已解析的环境变量值不会丢失。
+    """
 
     def __init__(
         self,
@@ -65,12 +105,33 @@ class TTSConfigStore:
             self._config = deep_merge(self._config, initial_config)
 
     def read(self) -> dict[str, Any]:
-        """Return a defensive copy of the current TTS config."""
+        """Return a defensive copy of the current TTS config.
+
+        返回当前 TTS 配置的防御性拷贝。
+        """
 
         return deepcopy(self._config)
 
     def update(self, patch: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
-        """Merge a partial config update and persist it by default."""
+        """Merge a partial config update and persist it by default.
+
+        合并部分配置更新，默认会持久化到磁盘。
+
+        When ``persist`` is true the on-disk YAML is refreshed first to avoid
+        overwriting concurrent external edits.
+
+        当 ``persist`` 为 True 时，会先从磁盘刷新配置，以避免覆盖并发的外部修改。
+
+        Args:
+            patch: Partial config dict to merge in.
+                   要合并的部分配置字典。
+            persist: Whether to write changes to disk.
+                     是否将变更写入磁盘。
+
+        Returns:
+            The full config after the merge.
+            合并后的完整配置。
+        """
 
         had_file = self.path.is_file()
         if persist:
@@ -82,7 +143,26 @@ class TTSConfigStore:
         return self.read()
 
     def replace(self, config: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
-        """Replace the current config after applying runtime defaults."""
+        """Replace the current config after applying runtime defaults.
+
+        替换当前配置，并重新应用运行时默认值。
+
+        Unlike :meth:`update`, this discards the previous config entirely and
+        applies ``DEFAULT_TTS_CONFIG`` as the base.
+
+        与 :meth:`update` 不同，此方法会完全丢弃之前的配置，
+        并以 ``DEFAULT_TTS_CONFIG`` 作为基础。
+
+        Args:
+            config: New config dict to set.
+                    要设置的新配置字典。
+            persist: Whether to write changes to disk.
+                     是否将变更写入磁盘。
+
+        Returns:
+            The full config after replacement.
+            替换后的完整配置。
+        """
 
         self._config = deep_merge(DEFAULT_TTS_CONFIG, config)
         self._persist_config = deepcopy(config)
@@ -91,7 +171,10 @@ class TTSConfigStore:
         return self.read()
 
     def save(self) -> None:
-        """Persist explicit config values without reformatting the YAML document."""
+        """Persist explicit config values without reformatting the YAML document.
+
+        将显式配置值持久化到磁盘，不重新格式化 YAML 文档。
+        """
 
         self._save_patch(self._persist_config)
 

--- a/src/tts/exceptions.py
+++ b/src/tts/exceptions.py
@@ -1,27 +1,55 @@
-"""TTS-specific exception hierarchy."""
+"""TTS-specific exception hierarchy.
+
+TTS 异常层次结构。
+
+Defines granular exceptions for configuration errors, provider availability,
+synthesis failures, rate limiting, and upstream API errors.
+
+定义了细粒度的异常，涵盖配置错误、提供商可用性、合成失败、速率限制和上游 API 错误。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
 
 class TTSError(Exception):
-    """Base exception for TTS failures."""
+    """Base exception for TTS failures.
+
+    TTS 失败的基类异常。
+    """
 
 
 class TTSConfigError(TTSError):
-    """Raised when TTS configuration is invalid."""
+    """Raised when TTS configuration is invalid.
+
+    当 TTS 配置无效时抛出。
+    """
 
 
 class TTSProviderUnavailableError(TTSError):
-    """Raised when a selected TTS provider cannot be used."""
+    """Raised when a selected TTS provider cannot be used.
+
+    当所选的 TTS 提供商不可用时抛出。
+    """
 
 
 class TTSSynthesisError(TTSError):
-    """Raised when text synthesis fails."""
+    """Raised when text synthesis fails.
+
+    当文本合成失败时抛出。
+    """
 
 
 class TTSRateLimitError(TTSSynthesisError):
-    """Raised when an upstream TTS provider reports rate limiting."""
+    """Raised when an upstream TTS provider reports rate limiting.
+
+    当上游 TTS 提供商报告速率限制时抛出。
+    """
 
 
 class TTSAPIError(TTSSynthesisError):
-    """Raised when an upstream TTS provider returns an API error."""
+    """Raised when an upstream TTS provider returns an API error.
+
+    当上游 TTS 提供商返回 API 错误时抛出。
+    """

--- a/src/tts/factory.py
+++ b/src/tts/factory.py
@@ -1,4 +1,15 @@
-"""Decorator-based TTS provider registry."""
+"""Decorator-based TTS provider registry.
+
+基于装饰器的 TTS 提供商注册表。
+
+Providers self-register via ``@TTSFactory.register("name", metadata=...)``
+so that new providers can be added without modifying the factory itself.
+
+提供商通过 ``@TTSFactory.register("name", metadata=...)`` 自注册，
+新增提供商时无需修改工厂本身。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -11,7 +22,24 @@ from .interface import TTSInterface
 
 @dataclass(frozen=True)
 class TTSProviderMetadata:
-    """Static metadata shown in provider list responses."""
+    """Static metadata shown in provider list responses.
+
+    提供商列表响应中展示的静态元数据。
+
+    Attributes:
+        name: Unique provider identifier (e.g. ``"edge_tts"``).
+              唯一提供商标识符（如 ``"edge_tts"``）。
+        display_name: Human-readable name for the UI.
+                      用于 UI 的人类可读名称。
+        provider_type: Either ``"cloud"`` or ``"local"``.
+                       ``"cloud"`` 或 ``"local"``。
+        supports_streaming: Whether the provider supports streaming synthesis.
+                            提供商是否支持流式合成。
+        media_type: Default audio MIME type (e.g. ``"audio/mpeg"``).
+                    默认音频 MIME 类型（如 ``"audio/mpeg"``）。
+        description: Short description of the provider.
+                     提供商的简短描述。
+    """
 
     name: str
     display_name: str
@@ -22,7 +50,15 @@ class TTSProviderMetadata:
 
 
 class TTSFactory:
-    """Class-scoped registry mapping provider name to provider class."""
+    """Class-scoped registry mapping provider name to provider class.
+
+    类级注册表，将提供商名称映射到提供商类。
+
+    All state is stored on the class itself so that every module importing
+    ``TTSFactory`` shares the same registry.
+
+    所有状态都存储在类本身上，因此每个导入 ``TTSFactory`` 的模块共享同一注册表。
+    """
 
     _registry: dict[str, type[TTSInterface]] = {}
     _metadata: dict[str, TTSProviderMetadata] = {}
@@ -34,7 +70,26 @@ class TTSFactory:
         *,
         metadata: TTSProviderMetadata,
     ) -> Callable[[type[TTSInterface]], type[TTSInterface]]:
-        """Return a decorator that registers a provider class."""
+        """Return a decorator that registers a provider class.
+
+        返回一个装饰器，用于注册提供商类。
+
+        The decorator stamps ``provider_name``, ``supports_streaming``, and
+        ``media_type`` onto the class and records it in the registry.
+
+        装饰器会将 ``provider_name``、``supports_streaming`` 和 ``media_type``
+        写入类属性，并将该类记录到注册表中。
+
+        Args:
+            name: Unique provider key used in config and API.
+                  配置和 API 中使用的唯一提供商键。
+            metadata: Static metadata for the provider list endpoint.
+                      提供商列表端点的静态元数据。
+
+        Returns:
+            A class decorator.
+            类装饰器。
+        """
 
         def wrapper(provider_class: type[TTSInterface]) -> type[TTSInterface]:
             provider_class.provider_name = name
@@ -48,7 +103,24 @@ class TTSFactory:
 
     @classmethod
     def create(cls, name: str, **kwargs: Any) -> TTSInterface:
-        """Instantiate a registered provider by name."""
+        """Instantiate a registered provider by name.
+
+        根据名称实例化已注册的提供商。
+
+        Args:
+            name: Provider key (e.g. ``"edge_tts"``).
+                  提供商键（如 ``"edge_tts"``）。
+            **kwargs: Constructor arguments forwarded to the provider class.
+                      传递给提供商构造函数的参数。
+
+        Returns:
+            An initialised :class:`TTSInterface` instance.
+            已初始化的 :class:`TTSInterface` 实例。
+
+        Raises:
+            ValueError: If ``name`` is not in the registry.
+                        如果 ``name`` 不在注册表中。
+        """
 
         if name not in cls._registry:
             available = sorted(cls._registry.keys())
@@ -57,13 +129,31 @@ class TTSFactory:
 
     @classmethod
     def available(cls) -> list[str]:
-        """Return sorted registered provider names."""
+        """Return sorted registered provider names.
+
+        返回已注册提供商名称的排序列表。
+        """
 
         return sorted(cls._registry.keys())
 
     @classmethod
     def metadata(cls, name: str) -> TTSProviderMetadata:
-        """Return static metadata for a registered provider."""
+        """Return static metadata for a registered provider.
+
+        返回已注册提供商的静态元数据。
+
+        Args:
+            name: Provider key.
+                  提供商键。
+
+        Returns:
+            The :class:`TTSProviderMetadata` for the provider.
+            该提供商的 :class:`TTSProviderMetadata`。
+
+        Raises:
+            ValueError: If ``name`` is not in the metadata registry.
+                        如果 ``name`` 不在元数据注册表中。
+        """
 
         if name not in cls._metadata:
             available = sorted(cls._metadata.keys())

--- a/src/tts/interface.py
+++ b/src/tts/interface.py
@@ -1,4 +1,14 @@
-"""TTS provider interface."""
+"""TTS provider interface.
+
+TTS 提供商接口定义。
+
+Defines the abstract base class and data structures that every TTS provider
+must implement.
+
+定义了每个 TTS 提供商必须实现的抽象基类和数据结构。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -10,7 +20,16 @@ from typing import Any
 
 @dataclass(frozen=True)
 class TTSHealth:
-    """Provider availability state."""
+    """Provider availability state.
+
+    提供商可用性状态。
+
+    Attributes:
+        available: Whether the provider is ready to accept requests.
+                   提供商是否准备好接受请求。
+        reason: Optional human-readable explanation when unavailable.
+                不可用时的可选人类可读说明。
+    """
 
     available: bool
     reason: str | None = None
@@ -18,7 +37,24 @@ class TTSHealth:
 
 @dataclass(frozen=True)
 class TTSVoice:
-    """Voice metadata shown by the settings UI."""
+    """Voice metadata shown by the settings UI.
+
+    设置界面中展示的语音元数据。
+
+    Attributes:
+        id: Unique voice identifier passed to ``synthesize(voice_id=...)``.
+            唯一语音标识符，传递给 ``synthesize(voice_id=...)``。
+        name: Human-readable display name.
+              人类可读的显示名称。
+        language: BCP-47 locale tag (e.g. ``"zh-CN"``).
+                  BCP-47 语言标签（如 ``"zh-CN"``）。
+        gender: ``"Male"`` or ``"Female"`` when known.
+                已知时为 ``"Male"`` 或 ``"Female"``。
+        description: Short description of the voice.
+                     语音的简短描述。
+        preview_url: URL to a short audio preview sample.
+                     短音频预览样本的 URL。
+    """
 
     id: str
     name: str
@@ -29,7 +65,16 @@ class TTSVoice:
 
 
 class TTSInterface(ABC):
-    """Base interface for all TTS providers."""
+    """Base interface for all TTS providers.
+
+    所有 TTS 提供商的基类接口。
+
+    Concrete providers subclass this, implement :meth:`synthesize` and
+    :meth:`get_voices`, and register themselves via ``@TTSFactory.register``.
+
+    具体提供商继承此类，实现 :meth:`synthesize` 和 :meth:`get_voices`，
+    并通过 ``@TTSFactory.register`` 注册自身。
+    """
 
     provider_name = "unknown"
     supports_streaming = False
@@ -46,7 +91,22 @@ class TTSInterface(ABC):
         voice_id: str | None = None,
         **kwargs: Any,
     ) -> bytes:
-        """Synthesize text and return complete audio bytes."""
+        """Synthesize text and return complete audio bytes.
+
+        合成文本并返回完整的音频字节数据。
+
+        Args:
+            text: The text to speak.
+                  要合成的文本。
+            voice_id: Optional voice identifier override.
+                      可选的语音标识符覆盖。
+            **kwargs: Provider-specific options.
+                      提供商特定的选项。
+
+        Returns:
+            Raw audio bytes in the provider's ``media_type`` format.
+            以提供商 ``media_type`` 格式编码的原始音频字节。
+        """
 
     async def synthesize_stream(
         self,
@@ -55,15 +115,55 @@ class TTSInterface(ABC):
         voice_id: str | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[bytes]:
-        """Reserved stream interface for future TTS optimization."""
+        """Reserved stream interface for future TTS optimization.
+
+        为未来 TTS 优化预留的流式接口。
+
+        Default implementation raises :class:`NotImplementedError`.
+        Providers that support streaming should override this method.
+
+        默认实现抛出 :class:`NotImplementedError`。
+        支持流式的提供商应重写此方法。
+
+        Args:
+            text: The text to speak.
+                  要合成的文本。
+            voice_id: Optional voice identifier override.
+                      可选的语音标识符覆盖。
+            **kwargs: Provider-specific options.
+                      提供商特定的选项。
+
+        Yields:
+            Audio chunks as they become available.
+            逐块返回可用的音频数据。
+        """
 
         raise NotImplementedError("Streaming TTS synthesis is not implemented")
 
     @abstractmethod
     async def get_voices(self) -> list[TTSVoice]:
-        """Return available voices for this provider."""
+        """Return available voices for this provider.
+
+        返回此提供商可用的语音列表。
+
+        Returns:
+            A list of :class:`TTSVoice` objects.
+            :class:`TTSVoice` 对象列表。
+        """
 
     def health(self) -> TTSHealth:
-        """Return provider availability without doing expensive work."""
+        """Return provider availability without doing expensive work.
+
+        返回提供商可用性状态，不做耗时操作。
+
+        Subclasses should override this to check prerequisites such as
+        package installation or API key configuration.
+
+        子类应重写此方法以检查前置条件，如包安装或 API 密钥配置。
+
+        Returns:
+            A :class:`TTSHealth` indicating readiness.
+            表示就绪状态的 :class:`TTSHealth`。
+        """
 
         return TTSHealth(available=True)

--- a/src/tts/providers/cosyvoice3_tts.py
+++ b/src/tts/providers/cosyvoice3_tts.py
@@ -1,4 +1,15 @@
-"""CosyVoice3 Gradio TTS provider."""
+"""CosyVoice3 Gradio TTS provider.
+
+CosyVoice3 Gradio 提供商。
+
+Wraps a local CosyVoice3 Gradio endpoint for complete-audio synthesis.
+Compatible with Open-LLM-VTuber's CosyVoice3 API layout.
+
+封装本地 CosyVoice3 Gradio 端点，用于完整音频合成。
+兼容 Open-LLM-VTuber 的 CosyVoice3 API 布局。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -15,11 +26,19 @@ from src.tts.interface import TTSHealth, TTSInterface, TTSVoice
 DEFAULT_PROMPT_WAV_URL = (
     "https://github.com/gradio-app/gradio/raw/main/test/test_files/audio_sample.wav"
 )
-DEFAULT_MODE = "\u9884\u8bad\u7ec3\u97f3\u8272"
-DEFAULT_SFT_VOICE = "\u4e2d\u6587\u5973"
+DEFAULT_MODE = "预训练音色"
+DEFAULT_SFT_VOICE = "中文女"
 
 
 def _load_gradio_client() -> tuple[Any, Any]:
+    """Import and return ``gradio_client.Client`` and ``handle_file``.
+
+    导入并返回 ``gradio_client.Client`` 和 ``handle_file``。
+
+    Raises:
+        TTSProviderUnavailableError: If the ``gradio-client`` package is missing.
+                                     如果 ``gradio-client`` 包未安装。
+    """
     try:
         from gradio_client import Client, handle_file
     except ImportError as error:
@@ -41,7 +60,21 @@ def _load_gradio_client() -> tuple[Any, Any]:
     ),
 )
 class CosyVoice3TTSProvider(TTSInterface):
-    """Complete-audio CosyVoice3 provider through the Gradio client."""
+    """Complete-audio CosyVoice3 provider through the Gradio client.
+
+    通过 Gradio 客户端实现的完整音频
+    CosyVoice3 提供商。
+
+    Uses the ``gradio_client`` package to call a local CosyVoice3 Gradio
+    endpoint.  Audio synthesis is offloaded to a thread via
+    :func:`asyncio.to_thread` because the Gradio client is synchronous.
+
+    使用 ``gradio_client`` 包调用本地
+    CosyVoice3 Gradio 端点。
+    由于 Gradio 客户端是同步的，
+    音频合成通过 :func:`asyncio.to_thread`
+    卸载到线程中执行。
+    """
 
     def __init__(self, **config: Any) -> None:
         super().__init__(**config)
@@ -63,6 +96,10 @@ class CosyVoice3TTSProvider(TTSInterface):
         self.media_type = "audio/wav"
 
     def health(self) -> TTSHealth:
+        """Check whether the Gradio client package is installed and URL is set.
+
+        检查 Gradio 客户端包是否已安装以及 URL 是否已配置。
+        """
         if not self.client_url:
             return TTSHealth(False, "cosyvoice3_tts.client_url is not configured")
         if importlib.util.find_spec("gradio_client") is None:
@@ -76,6 +113,24 @@ class CosyVoice3TTSProvider(TTSInterface):
         voice_id: str | None = None,
         **kwargs: Any,
     ) -> bytes:
+        """Synthesize text via the CosyVoice3 Gradio endpoint.
+
+        通过 CosyVoice3 Gradio 端点合成文本。
+
+        Args:
+            text: The text to synthesize.
+                  要合成的文本。
+            voice_id: Optional SFT voice name override.
+                      可选的 SFT 语音名称覆盖。
+            **kwargs: Additional Gradio parameters (``mode_checkbox_group``,
+                      ``sft_dropdown``, ``prompt_text``, ``speed``, etc.).
+                      额外的 Gradio 参数（``mode_checkbox_group``、
+                      ``sft_dropdown``、``prompt_text``、``speed`` 等）。
+
+        Returns:
+            WAV audio bytes.
+            WAV 音频字节。
+        """
         health = self.health()
         if not health.available:
             raise TTSProviderUnavailableError(health.reason or "cosyvoice3_tts is unavailable")
@@ -83,6 +138,10 @@ class CosyVoice3TTSProvider(TTSInterface):
         return await asyncio.to_thread(self._synthesize_sync, text, voice_id, kwargs)
 
     async def get_voices(self) -> list[TTSVoice]:
+        """Return the configured SFT voice as a single-element list.
+
+        返回已配置的 SFT 语音（单元素列表）。
+        """
         return [
             TTSVoice(
                 id=self.sft_dropdown,
@@ -130,6 +189,16 @@ class CosyVoice3TTSProvider(TTSInterface):
         return audio
 
     def _read_audio_result(self, result: Any) -> bytes:
+        """Recursively extract raw audio bytes from a Gradio result.
+
+        从 Gradio 结果中递归提取原始音频字节。
+
+        Handles bytes, file paths, dicts with ``path``/``name``/``file`` keys,
+        and lists/tuples by recursing into each element.
+
+        支持 bytes、文件路径、包含 ``path``/``name``/``file`` 键的字典，
+        以及列表/元组（递归处理每个元素）。
+        """
         if isinstance(result, bytes | bytearray):
             return bytes(result)
         if isinstance(result, str | os.PathLike):

--- a/src/tts/providers/edge_tts.py
+++ b/src/tts/providers/edge_tts.py
@@ -1,4 +1,14 @@
-"""Microsoft Edge TTS provider."""
+"""Microsoft Edge TTS provider.
+
+Microsoft Edge TTS 提供商。
+
+Uses the ``edge-tts`` Python package to access free Microsoft Edge neural
+voices.  No API key is required.
+
+使用 ``edge-tts`` Python 包访问免费的 Microsoft Edge 神经语音。无需 API 密钥。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -11,6 +21,18 @@ from src.tts.interface import TTSHealth, TTSInterface, TTSVoice
 
 
 def _media_type_from_format(audio_format: str) -> str:
+    """Map an audio format string to a MIME type.
+
+    将音频格式字符串映射为 MIME 类型。
+
+    Args:
+        audio_format: Format extension (e.g. ``"mp3"``, ``"wav"``).
+                      格式扩展名（如 ``"mp3"``、``"wav"``）。
+
+    Returns:
+        The corresponding MIME type string.
+        对应的 MIME 类型字符串。
+    """
     value = audio_format.lower().lstrip(".")
     if value == "mp3":
         return "audio/mpeg"
@@ -33,7 +55,16 @@ def _media_type_from_format(audio_format: str) -> str:
     ),
 )
 class EdgeTTSProvider(TTSInterface):
-    """Complete-audio Edge TTS provider."""
+    """Complete-audio Edge TTS provider.
+
+    完整音频 Edge TTS 提供商。
+
+    Collects all audio chunks from ``edge_tts.Communicate.stream()`` and
+    returns the concatenated result as a single ``bytes`` object.
+
+    从 ``edge_tts.Communicate.stream()`` 收集所有音频块，
+    并将拼接后的结果作为单个 ``bytes`` 对象返回。
+    """
 
     def __init__(self, **config: Any) -> None:
         super().__init__(**config)
@@ -45,6 +76,10 @@ class EdgeTTSProvider(TTSInterface):
         self.media_type = _media_type_from_format(self.output_format)
 
     def health(self) -> TTSHealth:
+        """Check whether the ``edge-tts`` package is installed and voice is set.
+
+        检查 ``edge-tts`` 包是否已安装以及语音是否已配置。
+        """
         if importlib.util.find_spec("edge_tts") is None:
             return TTSHealth(False, "Python package 'edge-tts' is not installed")
         if not self.voice:
@@ -58,6 +93,22 @@ class EdgeTTSProvider(TTSInterface):
         voice_id: str | None = None,
         **kwargs: Any,
     ) -> bytes:
+        """Synthesize text using the ``edge-tts`` package.
+
+        使用 ``edge-tts`` 包合成文本。
+
+        Args:
+            text: The text to synthesize.
+                  要合成的文本。
+            voice_id: Optional voice name (e.g. ``"zh-CN-XiaoxiaoNeural"``).
+                      可选的语音名称（如 ``"zh-CN-XiaoxiaoNeural"``）。
+            **kwargs: Optional overrides for ``rate``, ``pitch``, ``volume``.
+                      可选的 ``rate``、``pitch``、``volume`` 覆盖。
+
+        Returns:
+            MP3 (or configured format) audio bytes.
+            MP3（或配置的格式）音频字节。
+        """
         health = self.health()
         if not health.available:
             raise TTSProviderUnavailableError(health.reason or "edge_tts is unavailable")
@@ -91,6 +142,14 @@ class EdgeTTSProvider(TTSInterface):
         return bytes(audio)
 
     async def get_voices(self) -> list[TTSVoice]:
+        """Fetch all available Edge TTS voices from the service.
+
+        从服务端获取所有可用的 Edge TTS 语音。
+
+        Returns:
+            A list of :class:`TTSVoice` with locale and gender metadata.
+            包含语言和性别元数据的 :class:`TTSVoice` 列表。
+        """
         health = self.health()
         if not health.available:
             raise TTSProviderUnavailableError(health.reason or "edge_tts is unavailable")

--- a/src/tts/providers/gpt_sovits_tts.py
+++ b/src/tts/providers/gpt_sovits_tts.py
@@ -1,4 +1,15 @@
-"""GPT-SoVITS HTTP TTS provider."""
+"""GPT-SoVITS HTTP TTS provider.
+
+GPT-SoVITS HTTP TTS 提供商。
+
+Calls a local GPT-SoVITS HTTP API for text-to-speech synthesis.
+Compatible with Open-LLM-VTuber's GPT-SoVITS integration.
+
+调用本地 GPT-SoVITS HTTP API 进行文本转语音合成。
+兼容 Open-LLM-VTuber 的 GPT-SoVITS 集成。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -15,6 +26,18 @@ _BRACKETED_TEXT = re.compile(r"\[.*?\]")
 
 
 def _media_type_from_format(audio_format: str) -> str:
+    """Map an audio format string to a MIME type.
+
+    将音频格式字符串映射为 MIME 类型。
+
+    Args:
+        audio_format: Format extension (e.g. ``"mp3"``, ``"wav"``).
+                      格式扩展名（如 ``"mp3"``、``"wav"``）。
+
+    Returns:
+        The corresponding MIME type string.
+        对应的 MIME 类型字符串。
+    """
     value = audio_format.lower().lstrip(".")
     if value == "mp3":
         return "audio/mpeg"
@@ -37,7 +60,17 @@ def _media_type_from_format(audio_format: str) -> str:
     ),
 )
 class GPTSoVITSTTSProvider(TTSInterface):
-    """Complete-audio GPT-SoVITS provider."""
+    """Complete-audio GPT-SoVITS provider.
+
+    完整音频 GPT-SoVITS 提供商。
+
+    Sends synthesis requests to a local GPT-SoVITS HTTP endpoint via
+    :class:`httpx.AsyncClient`.  Bracketed text (e.g. ``[laugh]``) is
+    stripped before sending.
+
+    通过 :class:`httpx.AsyncClient` 向本地 GPT-SoVITS HTTP 端点发送合成请求。
+    发送前会移除方括号内的文本（如 ``[laugh]``）。
+    """
 
     def __init__(self, **config: Any) -> None:
         super().__init__(**config)
@@ -54,6 +87,10 @@ class GPTSoVITSTTSProvider(TTSInterface):
         self.media_type = _media_type_from_format(self.output_format)
 
     def health(self) -> TTSHealth:
+        """Check whether the API URL is configured.
+
+        检查 API URL 是否已配置。
+        """
         if not self.api_url:
             return TTSHealth(False, "gpt_sovits_tts.api_url is not configured")
         return TTSHealth(True, "HTTP endpoint availability is checked during synthesis")
@@ -65,6 +102,30 @@ class GPTSoVITSTTSProvider(TTSInterface):
         voice_id: str | None = None,
         **kwargs: Any,
     ) -> bytes:
+        """Synthesize text via the GPT-SoVITS HTTP API.
+
+        通过 GPT-SoVITS HTTP API 合成文本。
+
+        Args:
+            text: The text to synthesize.  Bracketed annotations are stripped.
+                  要合成的文本。方括号注释会被移除。
+            voice_id: Unused (voice is determined by ``ref_audio_path``).
+                      未使用（语音由 ``ref_audio_path`` 决定）。
+            **kwargs: Optional overrides for ``text_lang``, ``ref_audio_path``,
+                      ``prompt_text``, ``speed``, ``media_type``, etc.
+                      可选的 ``text_lang``、``ref_audio_path``、
+                      ``prompt_text``、``speed``、``media_type`` 等覆盖。
+
+        Returns:
+            Audio bytes in the configured format.
+            配置格式的音频字节。
+
+        Raises:
+            TTSAPIError: On HTTP errors or empty responses.
+                         HTTP 错误或空响应时抛出。
+            TTSRateLimitError: On HTTP 429 responses.
+                               HTTP 429 响应时抛出。
+        """
         health = self.health()
         if not health.available:
             raise TTSProviderUnavailableError(health.reason or "gpt_sovits_tts is unavailable")
@@ -100,6 +161,16 @@ class GPTSoVITSTTSProvider(TTSInterface):
         return response.content
 
     async def get_voices(self) -> list[TTSVoice]:
+        """Return a single default voice entry.
+
+        返回单个默认语音条目。
+
+        GPT-SoVITS voice identity is controlled by ``ref_audio_path``
+        and ``prompt_text`` rather than a voice list.
+
+        GPT-SoVITS 的语音身份由 ``ref_audio_path`` 和 ``prompt_text`` 控制，
+        而非语音列表。
+        """
         return [
             TTSVoice(
                 id="default",

--- a/src/tts/providers/siliconflow_tts.py
+++ b/src/tts/providers/siliconflow_tts.py
@@ -1,4 +1,15 @@
-"""SiliconFlow TTS provider."""
+"""SiliconFlow TTS provider.
+
+SiliconFlow TTS 提供商。
+
+Calls the SiliconFlow cloud audio/speech API for text-to-speech synthesis.
+Supports system voices and user-uploaded custom voices.
+
+调用 SiliconFlow 云端 audio/speech API 进行文本转语音合成。
+支持系统语音和用户上传的自定义语音。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -17,6 +28,18 @@ SYSTEM_VOICE_NAMES = ("alex", "benjamin", "charles", "david", "anna", "bella", "
 
 
 def _media_type_from_format(audio_format: str) -> str:
+    """Map an audio format string to a MIME type.
+
+    将音频格式字符串映射为 MIME 类型。
+
+    Args:
+        audio_format: Format extension (e.g. ``"mp3"``, ``"wav"``, ``"opus"``).
+                      格式扩展名（如 ``"mp3"``、``"wav"``、``"opus"``）。
+
+    Returns:
+        The corresponding MIME type string.
+        对应的 MIME 类型字符串。
+    """
     value = audio_format.lower().lstrip(".")
     if value == "mp3":
         return "audio/mpeg"
@@ -30,6 +53,10 @@ def _media_type_from_format(audio_format: str) -> str:
 
 
 def _secret_is_configured(value: str) -> bool:
+    """Check whether a secret value is a real credential (not an env placeholder).
+
+    检查密钥值是否为真实凭据（而非环境变量占位符）。
+    """
     return bool(value) and not (value.startswith("${") and value.endswith("}"))
 
 
@@ -45,7 +72,18 @@ def _secret_is_configured(value: str) -> bool:
     ),
 )
 class SiliconFlowTTSProvider(TTSInterface):
-    """Complete-audio SiliconFlow TTS provider."""
+    """Complete-audio SiliconFlow TTS provider.
+
+    完整音频 SiliconFlow TTS 提供商。
+
+    Sends synthesis requests to the SiliconFlow audio/speech REST API.
+    System voices are derived from the configured model; custom voices are
+    fetched from the ``/v1/audio/voice/list`` endpoint when an API key is set.
+
+    向 SiliconFlow audio/speech REST API 发送合成请求。
+    系统语音由配置的模型派生；当设置了 API 密钥时，
+    从 ``/v1/audio/voice/list`` 端点获取自定义语音。
+    """
 
     def __init__(self, **config: Any) -> None:
         super().__init__(**config)
@@ -64,6 +102,10 @@ class SiliconFlowTTSProvider(TTSInterface):
         self.media_type = _media_type_from_format(self.response_format)
 
     def health(self) -> TTSHealth:
+        """Check whether API URL and API key are configured.
+
+        检查 API URL 和 API 密钥是否已配置。
+        """
         if not self.api_url:
             return TTSHealth(False, "siliconflow_tts.api_url is not configured")
         if not _secret_is_configured(self.api_key):
@@ -77,6 +119,30 @@ class SiliconFlowTTSProvider(TTSInterface):
         voice_id: str | None = None,
         **kwargs: Any,
     ) -> bytes:
+        """Synthesize text via the SiliconFlow audio/speech API.
+
+        通过 SiliconFlow audio/speech API 合成文本。
+
+        Args:
+            text: The text to synthesize.
+                  要合成的文本。
+            voice_id: Optional voice identifier (e.g. ``"model:claire"``).
+                      可选的语音标识符（如 ``"model:claire"``）。
+            **kwargs: Optional overrides for ``model``, ``voice``,
+                      ``response_format``, ``sample_rate``, ``speed``, ``gain``.
+                      可选的 ``model``、``voice``、``response_format``、
+                      ``sample_rate``、``speed``、``gain`` 覆盖。
+
+        Returns:
+            Audio bytes in the configured format.
+            配置格式的音频字节。
+
+        Raises:
+            TTSAPIError: On HTTP errors or empty responses.
+                         HTTP 错误或空响应时抛出。
+            TTSRateLimitError: On HTTP 429 responses.
+                               HTTP 429 响应时抛出。
+        """
         health = self.health()
         if not health.available:
             raise TTSProviderUnavailableError(health.reason or "siliconflow_tts is unavailable")
@@ -116,6 +182,21 @@ class SiliconFlowTTSProvider(TTSInterface):
         return response.content
 
     async def get_voices(self) -> list[TTSVoice]:
+        """Return system voices for the configured model plus any custom voices.
+
+        返回已配置模型的系统语音及自定义语音。
+
+        System voices (alex, benjamin, etc.) are always included.
+        Custom voices are fetched from the API only when a valid API key
+        is configured.
+
+        系统语音（alex、benjamin 等）始终包含。
+        仅在配置了有效 API 密钥时才会从 API 获取自定义语音。
+
+        Returns:
+            A deduplicated list of :class:`TTSVoice`.
+            去重后的 :class:`TTSVoice` 列表。
+        """
         voices = self._system_voices_for_model(self.default_model)
         if _secret_is_configured(self.api_key):
             voices.extend(await self._fetch_custom_voices())

--- a/src/tts/service.py
+++ b/src/tts/service.py
@@ -1,4 +1,15 @@
-"""TTS application service."""
+"""TTS application service.
+
+TTS 应用服务层。
+
+Orchestrates configuration, provider health checks, voice listing,
+provider switching, and text synthesis behind a single façade.
+
+协调配置管理、提供商健康检查、语音列表、提供商切换和文本合成，
+提供统一的门面接口。
+
+Reference: docs/TTS模块设计文档.md
+"""
 
 from __future__ import annotations
 
@@ -15,27 +26,79 @@ from .interface import TTSVoice
 
 SENSITIVE_CONFIG_KEYS = {"api_key", "token", "secret", "password"}
 SENSITIVE_CONFIG_MASK = "********"
+"""Mask value used to hide sensitive fields in API responses.
+用于在 API 响应中隐藏敏感字段的掩码值。
+"""
 PROVIDER_WRITE_ALLOWLISTS: dict[str, set[str]] = {
     "edge_tts": {"voice", "rate"},
     "gpt_sovits_tts": set(),
     "siliconflow_tts": {"default_voice", "stream"},
     "cosyvoice3_tts": {"stream", "speed"},
 }
+"""Per-provider set of config keys that the frontend is allowed to write.
+Keys not in the allowlist are stripped before persisting.
+每个提供商允许前端写入的配置键集合。不在白名单中的键会在持久化前被移除。
+"""
 
 
 class TTSService:
-    """Coordinate TTS config, provider health, switching, voices, and synthesis."""
+    """Coordinate TTS config, provider health, switching, voices, and synthesis.
+
+    协调 TTS 配置、提供商健康检查、切换、语音列表和合成。
+
+    This is the main entry point consumed by the FastAPI router layer.
+    It delegates config persistence to :class:`TTSConfigStore` and provider
+    instantiation to :class:`TTSFactory`.
+
+    这是 FastAPI 路由层使用的主要入口。
+    它将配置持久化委托给 :class:`TTSConfigStore`，
+    将提供商实例化委托给 :class:`TTSFactory`。
+    """
 
     def __init__(self, config_store: TTSConfigStore) -> None:
         self.config_store = config_store
 
     def get_config(self) -> dict[str, Any]:
-        """Return persisted OLV-shaped TTS config."""
+        """Return persisted OLV-shaped TTS config.
+
+        返回持久化的 OLV 格式 TTS 配置。
+
+        Sensitive values (API keys, tokens) are masked with ``"********"``.
+        敏感值（API 密钥、令牌）会被掩码为 ``"********"``。
+
+        Returns:
+            A dict safe for API responses.
+            可安全用于 API 响应的字典。
+        """
 
         return self._public_config(self.config_store.read())
 
     def update_config(self, patch: dict[str, Any], *, persist: bool = True) -> dict[str, Any]:
-        """Merge and persist a partial OLV-shaped TTS config update."""
+        """Merge and persist a partial OLV-shaped TTS config update.
+
+        合并并持久化部分 OLV 格式 TTS 配置更新。
+
+        Masked sensitive values and forbidden provider fields are stripped
+        before merging.  If the patch changes ``tts_model``, the new provider
+        is validated first.
+
+        掩码的敏感值和禁止的提供商字段会在合并前被移除。
+        如果补丁更改了 ``tts_model``，新提供商会被先验证。
+
+        Args:
+            patch: Partial config dict from the API request.
+                   来自 API 请求的部分配置字典。
+            persist: Whether to write to disk.
+                     是否写入磁盘。
+
+        Returns:
+            The full config after merging (sensitive values masked).
+            合并后的完整配置（敏感值已掩码）。
+
+        Raises:
+            TTSConfigError: If the target provider is not registered.
+                            如果目标提供商未注册。
+        """
 
         patch = self._strip_masked_sensitive_values(patch)
         patch = self._strip_forbidden_provider_writes(patch)
@@ -45,13 +108,45 @@ class TTSService:
         return self.config_store.update(patch, persist=persist)
 
     def switch_provider(self, provider: str, *, persist: bool = True) -> dict[str, Any]:
-        """Switch the active TTS provider."""
+        """Switch the active TTS provider.
+
+        切换当前活跃的 TTS 提供商。
+
+        Args:
+            provider: Provider name (e.g. ``"edge_tts"``).
+                      提供商名称（如 ``"edge_tts"``）。
+            persist: Whether to write to disk.
+                     是否写入磁盘。
+
+        Returns:
+            The full config after switching.
+            切换后的完整配置。
+
+        Raises:
+            TTSConfigError: If the provider is not registered.
+                            如果提供商未注册。
+        """
 
         self._ensure_provider_registered(provider)
         return self.config_store.update({"tts_model": provider}, persist=persist)
 
     def list_providers(self) -> list[dict[str, Any]]:
-        """Return registered provider metadata plus health/config state."""
+        """Return registered provider metadata plus health/config state.
+
+        返回已注册提供商的元数据及其健康状态和配置信息。
+
+        Each entry contains: ``name``, ``display_name``, ``provider_type``,
+        ``description``, ``active``, ``available``, ``reason``,
+        ``supports_streaming``, ``media_type``, and ``config``.
+
+        每个条目包含：``name``、``display_name``、``provider_type``、
+        ``description``、``active``、``available``、``reason``、
+        ``supports_streaming``、``media_type`` 和 ``config``。
+
+        Returns:
+            A list of provider info dicts.
+            提供商信息字典列表。
+        """
 
         config = self.config_store.read()
         active_provider = self._active_provider(config)
@@ -79,7 +174,15 @@ class TTSService:
         return providers
 
     def health(self) -> dict[str, Any]:
-        """Return active and all-provider TTS health state."""
+        """Return active and all-provider TTS health state.
+
+        返回活跃提供商和所有提供商的 TTS 健康状态。
+
+        Returns:
+            A dict with ``active_provider``, ``active_available``,
+            and ``providers`` keys.
+            包含 ``active_provider``、``active_available`` 和 ``providers`` 键的字典。
+        """
 
         config = self.config_store.read()
         active_provider = self._active_provider(config)
@@ -95,7 +198,18 @@ class TTSService:
         }
 
     async def get_voices(self, provider: str | None = None) -> dict[str, Any]:
-        """Return voices for the active or requested TTS provider."""
+        """Return voices for the active or requested TTS provider.
+
+        返回活跃或指定 TTS 提供商的可用语音列表。
+
+        Args:
+            provider: Optional provider name; defaults to the active provider.
+                      可选的提供商名称；默认为活跃提供商。
+
+        Returns:
+            A dict with ``provider`` name and ``voices`` list.
+            包含 ``provider`` 名称和 ``voices`` 列表的字典。
+        """
 
         config = self.config_store.read()
         provider_name = provider or self._active_provider(config)
@@ -114,7 +228,33 @@ class TTSService:
         voice_id: str | None = None,
         options: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Synthesize text with the selected provider and return audio bytes."""
+        """Synthesize text with the selected provider and return audio bytes.
+
+        使用选定的提供商合成文本并返回音频字节。
+
+        Logs timing and audio size on success; logs the traceback on failure.
+        成功时记录耗时和音频大小；失败时记录完整堆栈。
+
+        Args:
+            text: The text to synthesize (must not be empty).
+                  要合成的文本（不能为空）。
+            provider: Optional provider name; defaults to the active provider.
+                      可选的提供商名称；默认为活跃提供商。
+            voice_id: Optional voice identifier.
+                      可选的语音标识符。
+            options: Extra keyword arguments forwarded to the provider.
+                     传递给提供商的额外关键字参数。
+
+        Returns:
+            A dict with ``provider``, ``audio`` (bytes), and ``media_type``.
+            包含 ``provider``、``audio``（字节）和 ``media_type`` 的字典。
+
+        Raises:
+            TTSSynthesisError: If ``text`` is empty.
+                               如果 ``text`` 为空。
+            TTSProviderUnavailableError: If the provider's health check fails.
+                                         如果提供商的健康检查失败。
+        """
 
         text = text.strip()
         if not text:

--- a/src/utils/yaml_text.py
+++ b/src/utils/yaml_text.py
@@ -1,4 +1,7 @@
-"""Text-level YAML helpers for preserving comments and layout on write."""
+"""Text-level YAML helpers for preserving comments and layout on write.
+
+文本级 YAML 辅助工具，在写入时保留注释和格式布局。
+"""
 
 from __future__ import annotations
 
@@ -11,7 +14,10 @@ _YAML_KEY_RE = re.compile(r"^(?P<indent> *)(?P<key>[A-Za-z0-9_-]+):(?P<tail>.*)$
 
 
 def patch_yaml_values(path: Path, patch: Mapping[str, Any]) -> None:
-    """Patch only supplied mapping values in a YAML file without reformatting it."""
+    """Patch only supplied mapping values in a YAML file without reformatting it.
+
+    仅修补 YAML 文件中提供的映射值，不重新格式化文件。
+    """
 
     if not patch:
         return
@@ -25,7 +31,10 @@ def patch_yaml_values(path: Path, patch: Mapping[str, Any]) -> None:
 
 
 def render_yaml_mapping(mapping: Mapping[str, Any]) -> str:
-    """Render a small YAML mapping without using a YAML formatter."""
+    """Render a small YAML mapping without using a YAML formatter.
+
+    在不使用 YAML 格式化器的情况下渲染小型 YAML 映射。
+    """
 
     lines = _render_mapping_lines(mapping, 0, "\n")
     return "".join(lines).rstrip("\n")


### PR DESCRIPTION
## Summary

- Add bilingual (English + Chinese) docstrings to all public classes, methods, and module-level documentation across 10 backend modules
- Follows the established pattern from `src/llm/exceptions.py` and `src/llm/factory.py`
- 47 files changed, 2108 insertions, 293 deletions

## Modules Covered

- [x] `src/memory/` — Memory manager, compression, session management
- [x] `src/agent/` — ChatAgent, Persona
- [x] `src/routes/` — FastAPI route handlers
- [x] `src/storage/` — Storage abstraction layer
- [x] `src/auth/` — Authentication module
- [x] `src/asr/` — ASR providers
- [x] `src/tts/` — TTS providers
- [x] `src/models/` — Pydantic schemas
- [x] `src/middleware/` — FastAPI middleware
- [x] `src/utils/` — Utility functions
- [ ] `src/translate/` — Skipped (empty module)

## Guidelines Followed

- Only documented public classes, public methods, and complex internal logic
- No comments for self-explanatory code
- Chinese translation as second paragraph (bilingual style)
- Included `Reference:` links to design docs where applicable
- `uv run ruff check src/` passes
- `uv run pytest` — 374 passed, 4 deselected

Closes #12